### PR TITLE
Add aws-etcd Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,6 @@ deploy:
   on:
     repo: sky-uk/etcd-bootstrap
     tags: true
+
+after_success:
+  - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then make release; fi

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 pkgs := $(shell go list ./... | grep -v /vendor/)
 files := $(shell find . -path ./vendor -prune -o -name '*.go' -print)
 
-.PHONY: all format test build vet lint checkformat check
+.PHONY: all format test build vet lint checkformat check docker release
 
 all : format check install
 check : vet lint test
@@ -14,7 +14,7 @@ format :
 
 build :
 	@echo "== build"
-	@go build -v
+	@GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -v
 
 install :
 	@echo "== install"
@@ -44,3 +44,24 @@ test :
 	@echo "== run tests"
 	@go test -race $(pkgs)
 
+git_rev := $(shell git rev-parse --short HEAD)
+git_tag := $(shell git tag --points-at=$(git_rev))
+etcd_version := v2.3.7
+image := skycirrus/aws-etcd-$(etcd_version)
+
+docker : build
+	@echo "== build"
+	cp etcd-bootstrap aws-etcd/
+	docker build -t $(image):latest aws-etcd/
+	rm -f aws-etcd/etcd-bootstrap
+
+release : docker
+	@echo "== release"
+ifeq ($(strip $(git_tag)),)
+	@echo "no tag on $(git_rev), skipping release"
+else
+	@echo "releasing $(image)"
+	@docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD)
+	docker tag $(image):latest $(image):$(git_tag)
+	docker push $(image):$(git_tag)
+endif

--- a/README.md
+++ b/README.md
@@ -7,7 +7,16 @@ to automatically join existing clusters and create new ones if necessary.
 
 It's intended for use with AWS Auto Scaling groups and etcd2.
 
-# Usage
+## aws-etcd container
+
+etcd2 container that bootstraps in AWS. Run it the same as the etcd container:
+
+    docker run skycirrus/aws-etcd-v2.3.7 -h
+
+This will take care of setting all the required flags to create or join an existing
+etcd cluster, based on the ASG the local instance is on.
+
+## Command usage
 
 Create instances inside of an ASG. Then run: 
 

--- a/aws-etcd/Dockerfile
+++ b/aws-etcd/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.4
+
+ENV VERSION v2.3.7
+COPY checksums /
+
+RUN apk add --no-cache curl
+
+RUN curl -OLv https://github.com/coreos/etcd/releases/download/$VERSION/etcd-$VERSION-linux-amd64.tar.gz \
+    && sha256sum -c checksums \
+    && tar xzvf etcd-$VERSION-linux-amd64.tar.gz \
+    && cp etcd-$VERSION-linux-amd64/etcd / \
+    && cp etcd-$VERSION-linux-amd64/etcdctl / \
+    && rm -rf etcd-$VERSION-linux-amd64 \
+    && rm -f *.tar.gz
+
+COPY etcd-bootstrap /
+COPY start-etcd.sh /
+
+ENTRYPOINT ["/start-etcd.sh"]

--- a/aws-etcd/checksums
+++ b/aws-etcd/checksums
@@ -1,0 +1,1 @@
+ab102d271026a4060c9f85ecad11f454d82b1df7b8e676cc3da69f67eb078729  etcd-v2.3.7-linux-amd64.tar.gz

--- a/aws-etcd/start-etcd.sh
+++ b/aws-etcd/start-etcd.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+/etcd-bootstrap -o /etcd-bootstrap.conf
+cat /etcd-bootstrap.conf
+set -a
+source /etcd-bootstrap.conf
+set +a
+exec /etcd $@


### PR DESCRIPTION
Builds skycirrus/aws-etcd-v2.3.7 which self bootstraps inside an AWS
ASG.

This gets automatically built and pushed on a tag creation in master.