### PR TITLE
Cluster state should be new if peerURL exists

### DIFF
--- a/lib/bootstrap_test.go
+++ b/lib/bootstrap_test.go
@@ -88,7 +88,7 @@ func TestExistingCluster(t *testing.T) {
 	bootstrapper := New(testASG, etcdCluster)
 	vars := strings.Split(bootstrapper.Bootstrap(), "\n")
 
-	assert.Contains(vars, "ETCD_INITIAL_CLUSTER_STATE=existing")
+	assert.Contains(vars, "ETCD_INITIAL_CLUSTER_STATE=new")
 	assert.Contains(vars, "ETCD_INITIAL_CLUSTER=e1=http://10.50.99.1:2380,"+
 		"e2=http://10.50.199.1:2380,e3=http://10.50.155.1:2380")
 	assert.Contains(vars, "ETCD_INITIAL_ADVERTISE_PEER_URLS=http://10.50.199.1:2380")


### PR DESCRIPTION
Previous logic change for joining broke bootstrapping of a new cluster.
If the node already exists in the peer URL list, it should set the
initial cluster state to new so it can correctly bootstrap a new
cluster.