### PR TITLE
Fix start-etcd.sh for vmware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
+# v1.1.1
+
+* Fix vmware docker image.
+
 # v1.1.0
-Add support for discovering cluster members using the GCP API.
-Renames aws image to cloud.
-Updates etcd version to 2.3.8.
+
+* Add support for discovering cluster members using the GCP API.
+* Renames aws image to cloud.
+* Updates etcd version to 2.3.8.
 
 # v1.0.0
 

--- a/vmware-etcd/start-etcd.sh
+++ b/vmware-etcd/start-etcd.sh
@@ -6,7 +6,15 @@ if [ -n "$VMWARE_CREDENTIALS" ]; then
         exit 1
     else
         source $VMWARE_CREDENTIALS
-        ETCD_BOOTSTRAP_FLAGS+=" -vmware-username $VMWARE_USERNAME -vmware-password $VMWARE_PASSWORD"
+        if [ -z "$VMWARE_USERNAME" ]; then
+            echo '$VMWARE_USERNAME is missing'
+            exit 1
+        fi
+        if [ -z "$VMWARE_PASSWORD" ]; then
+            echo '$VMWARE_USERNAME is missing'
+            exit 1
+        fi
+        ETCD_BOOTSTRAP_FLAGS="$ETCD_BOOTSTRAP_FLAGS -vmware-username $VMWARE_USERNAME -vmware-password $VMWARE_PASSWORD"
     fi
 fi
 


### PR DESCRIPTION
Failed as alpine sh doesn't support `+=`.