### PR TITLE
Allow bootstrapping functionality to be invoked without starting etcd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.2.0
+
+* Split `start-etcd.sh` into `bootstrap.sh` and `etcd.sh`, to allow etcd-bootstrap to be used with coreos etcd v3+ images.
+
 # v1.1.1
 
 * Fix vmware docker image.

--- a/README.md
+++ b/README.md
@@ -21,17 +21,22 @@ etcd2 container that bootstraps in the cloud. Run it the same as the etcd contai
 You can pass in any flag that etcd takes normally.
 
 
-Alternatively, cloud-etcd may be used to generate a startup script for etcd only, which may then be used with this image, or v3+ images.
+Alternatively, cloud-etcd may be used to generate a startup script for etcd only, which may then be used with this
+image, or v3+ images.
 
-    docker run -v OUTPUT_DIR:/bootstrap --entrypoint=/bootstrap.sh skycirrus/cloud-etcd-v2.3.8:1.2.0 -h # lists all the etcd-bootstrap options
+    docker run -v BOOTSTRAP_DIR:/bootstrap --entrypoint=/bootstrap.sh skycirrus/cloud-etcd-v2.3.8:1.2.0 -h # lists all the etcd-bootstrap options
 
-And then to run etcd v2:
+And then to run etcd v2 using this image:
 
-    docker run -v OUTPUT_DIR:/bootstrap --entrypoint=/etcd.sh skycirrus/cloud-etcd-v2.3.8:1.2.0 -h # lists all the etcd options
+    docker run -v BOOTSTRAP_DIR:/bootstrap --entrypoint=/bootstrap/etcd.sh skycirrus/cloud-etcd-v2.3.8:1.2.0 -h # lists all the etcd options
     
-Or for etcd v3+:
+Or for etcd v3+ using the coreos image:
 
-    docker run -v OUTPUT_DIR:/bootstrap --entrypoint=/bootstrap/etcd.sh quay.io/coreos/etcd:v3.2 -h # lists all the etcd options 
+    docker run -v BOOTSTRAP_DIR:/bootstrap --entrypoint=/bootstrap/etcd.sh quay.io/coreos/etcd:v3.2 -h # lists all the etcd options 
+
+The startup script is generated and placed into the volume mounted bootstrap directory. This must be mounted into the
+container which will run etcd, and the entrypoint must be changed to the generated script. The location of this
+bootstrap directory may be customised by using `-e BOOTSTRAP_DIR=[NEW LOCATION]`.
 
 ### AWS
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,22 @@ The cloud type used is determined by the `-cloud (aws|vmware|gcp)` command line 
 
 etcd2 container that bootstraps in the cloud. Run it the same as the etcd container:
 
-    docker run skycirrus/cloud-etcd-v2.3.8:1.1.0 -h # lists all the etcd options
+    docker run skycirrus/cloud-etcd-v2.3.8:1.2.0 -h # lists all the etcd options
 
 You can pass in any flag that etcd takes normally.
+
+
+Alternatively, cloud-etcd may be used to generate a startup script for etcd only, which may then be used with this image, or v3+ images.
+
+    docker run -v OUTPUT_DIR:/bootstrap --entrypoint=/bootstrap.sh skycirrus/cloud-etcd-v2.3.8:1.2.0 -h # lists all the etcd-bootstrap options
+
+And then to run etcd v2:
+
+    docker run -v OUTPUT_DIR:/bootstrap --entrypoint=/etcd.sh skycirrus/cloud-etcd-v2.3.8:1.2.0 -h # lists all the etcd options
+    
+Or for etcd v3+:
+
+    docker run -v OUTPUT_DIR:/bootstrap --entrypoint=/bootstrap/etcd.sh quay.io/coreos/etcd:v3.2 -h # lists all the etcd options 
 
 ### AWS
 
@@ -40,7 +53,7 @@ To pass flags to etcd-bootstrap, set the `ETCD_BOOTSTRAP_FLAGS` environment vari
 
 ## vmware-etcd container
 
-On top of the functionality provided by the aws-etcd container, the vmware-etcd container has support to read
+On top of the functionality provided by the cloud-etcd container, the vmware-etcd container has support to read
 credentials from a user specified file.
 
 To use this feature, set the `VMWARE_CREDENTIALS` environment variable with reference to the location of the file that
@@ -56,7 +69,7 @@ append the appropriate flags to `ETCD_BOOTSTRAP_FLAGS`.
 
     docker run -e VMWARE_CREDENTIALS='/etc/vmware-credentials' \
                -e ETCD_BOOTSTRAP_FLAGS='-cloud vmware ...' \
-               skycirrus/vmware-etcd-v2.3.8:1.1.0
+               skycirrus/vmware-etcd-v2.3.8:1.2.0
 
 ## Command usage
 

--- a/cloud-etcd/Dockerfile
+++ b/cloud-etcd/Dockerfile
@@ -8,12 +8,14 @@ RUN apk add --no-cache curl
 RUN curl -OLv https://github.com/coreos/etcd/releases/download/$VERSION/etcd-$VERSION-linux-amd64.tar.gz \
     && sha256sum -c checksums \
     && tar xzvf etcd-$VERSION-linux-amd64.tar.gz \
-    && cp etcd-$VERSION-linux-amd64/etcd / \
-    && cp etcd-$VERSION-linux-amd64/etcdctl / \
+    && cp etcd-$VERSION-linux-amd64/etcd /usr/local/bin \
+    && cp etcd-$VERSION-linux-amd64/etcdctl /usr/local/bin \
     && rm -rf etcd-$VERSION-linux-amd64 \
     && rm -f *.tar.gz
 
 COPY etcd-bootstrap /
+COPY bootstrap.sh /
+COPY etcd.sh /
 COPY start-etcd.sh /
 
 ENTRYPOINT ["/start-etcd.sh"]

--- a/cloud-etcd/bootstrap.sh
+++ b/cloud-etcd/bootstrap.sh
@@ -1,4 +1,10 @@
 #!/bin/sh -e
 
-/etcd-bootstrap -o /bootstrap/etcd-bootstrap.conf $@
-cp /etcd.sh /bootstrap
+if [ -z $BOOTSTRAP_DIR ] ; then
+    BOOTSTRAP_DIR=/bootstrap
+fi
+
+/etcd-bootstrap -o $BOOTSTRAP_DIR/etcd-bootstrap.conf $@
+
+# Copy etcd.sh startup to the output directory so that it may be used to load the config before starting etcd
+cp /etcd.sh $BOOTSTRAP_DIR

--- a/cloud-etcd/bootstrap.sh
+++ b/cloud-etcd/bootstrap.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+/etcd-bootstrap -o /bootstrap/etcd-bootstrap.conf $@
+cp /etcd.sh /bootstrap

--- a/cloud-etcd/bootstrap.sh
+++ b/cloud-etcd/bootstrap.sh
@@ -1,8 +1,6 @@
 #!/bin/sh -e
 
-if [ -z $BOOTSTRAP_DIR ] ; then
-    BOOTSTRAP_DIR=/bootstrap
-fi
+BOOTSTRAP_DIR=${BOOTSTRAP_DIR:="/bootstrap"}
 
 /etcd-bootstrap -o $BOOTSTRAP_DIR/etcd-bootstrap.conf $@
 

--- a/cloud-etcd/etcd.sh
+++ b/cloud-etcd/etcd.sh
@@ -1,6 +1,10 @@
 #!/bin/sh -e
 
+if [ -z $BOOTSTRAP_DIR ] ; then
+    BOOTSTRAP_DIR=/bootstrap
+fi
+
 set -a
-source /bootstrap/etcd-bootstrap.conf
+source $BOOTSTRAP_DIR/etcd-bootstrap.conf
 set +a
 exec /usr/local/bin/etcd $@

--- a/cloud-etcd/etcd.sh
+++ b/cloud-etcd/etcd.sh
@@ -1,8 +1,6 @@
 #!/bin/sh -e
 
-if [ -z $BOOTSTRAP_DIR ] ; then
-    BOOTSTRAP_DIR=/bootstrap
-fi
+BOOTSTRAP_DIR=${BOOTSTRAP_DIR:="/bootstrap"}
 
 set -a
 source $BOOTSTRAP_DIR/etcd-bootstrap.conf

--- a/cloud-etcd/etcd.sh
+++ b/cloud-etcd/etcd.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+set -a
+source /bootstrap/etcd-bootstrap.conf
+set +a
+exec /usr/local/bin/etcd $@

--- a/cloud-etcd/start-etcd.sh
+++ b/cloud-etcd/start-etcd.sh
@@ -1,7 +1,4 @@
 #!/bin/sh -e
 
-/etcd-bootstrap -o /etcd-bootstrap.conf $ETCD_BOOTSTRAP_FLAGS
-set -a
-source /etcd-bootstrap.conf
-set +a
-exec /etcd $@
+/bootstrap.sh $ETCD_BOOTSTRAP_FLAGS
+/etcd.sh

--- a/vmware-etcd/bootstrap.sh
+++ b/vmware-etcd/bootstrap.sh
@@ -19,5 +19,11 @@ if [ -n "$VMWARE_CREDENTIALS" ]; then
     fi
 fi
 
-/etcd-bootstrap -o /bootstrap/etcd-bootstrap.conf $@
-cp /etcd.sh /bootstrap
+if [ -z $BOOTSTRAP_DIR ] ; then
+    BOOTSTRAP_DIR=/bootstrap
+fi
+
+/etcd-bootstrap -o $BOOTSTRAP_DIR/etcd-bootstrap.conf $@
+
+# Copy etcd.sh startup to the output directory so that it may be used to load the config before starting etcd
+cp /etcd.sh $BOOTSTRAP_DIR

--- a/vmware-etcd/bootstrap.sh
+++ b/vmware-etcd/bootstrap.sh
@@ -1,0 +1,23 @@
+#!/bin/sh -e
+
+set -e
+if [ -n "$VMWARE_CREDENTIALS" ]; then
+    if [ ! -f "$VMWARE_CREDENTIALS" ]; then
+        echo "ERROR: specified credentials file not found"
+        exit 1
+    else
+        source $VMWARE_CREDENTIALS
+        if [ -z "$VMWARE_USERNAME" ]; then
+            echo '$VMWARE_USERNAME is missing'
+            exit 1
+        fi
+        if [ -z "$VMWARE_PASSWORD" ]; then
+            echo '$VMWARE_USERNAME is missing'
+            exit 1
+        fi
+        ETCD_BOOTSTRAP_FLAGS="$ETCD_BOOTSTRAP_FLAGS -vmware-username $VMWARE_USERNAME -vmware-password $VMWARE_PASSWORD"
+    fi
+fi
+
+/etcd-bootstrap -o /bootstrap/etcd-bootstrap.conf $@
+cp /etcd.sh /bootstrap

--- a/vmware-etcd/bootstrap.sh
+++ b/vmware-etcd/bootstrap.sh
@@ -19,9 +19,7 @@ if [ -n "$VMWARE_CREDENTIALS" ]; then
     fi
 fi
 
-if [ -z $BOOTSTRAP_DIR ] ; then
-    BOOTSTRAP_DIR=/bootstrap
-fi
+BOOTSTRAP_DIR=${BOOTSTRAP_DIR:="/bootstrap"}
 
 /etcd-bootstrap -o $BOOTSTRAP_DIR/etcd-bootstrap.conf $@
 

--- a/vmware-etcd/etcd.sh
+++ b/vmware-etcd/etcd.sh
@@ -1,6 +1,10 @@
 #!/bin/sh -e
 
+if [ -z $BOOTSTRAP_DIR ] ; then
+    BOOTSTRAP_DIR=/bootstrap
+fi
+
 set -a
-source /bootstrap/etcd-bootstrap.conf
+source $BOOTSTRAP_DIR/etcd-bootstrap.conf
 set +a
 exec /usr/local/bin/etcd $@

--- a/vmware-etcd/etcd.sh
+++ b/vmware-etcd/etcd.sh
@@ -1,8 +1,6 @@
 #!/bin/sh -e
 
-if [ -z $BOOTSTRAP_DIR ] ; then
-    BOOTSTRAP_DIR=/bootstrap
-fi
+BOOTSTRAP_DIR=${BOOTSTRAP_DIR:="/bootstrap"}
 
 set -a
 source $BOOTSTRAP_DIR/etcd-bootstrap.conf

--- a/vmware-etcd/etcd.sh
+++ b/vmware-etcd/etcd.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+set -a
+source /bootstrap/etcd-bootstrap.conf
+set +a
+exec /usr/local/bin/etcd $@

--- a/vmware-etcd/start-etcd.sh
+++ b/vmware-etcd/start-etcd.sh
@@ -1,25 +1,4 @@
 #!/bin/sh -e
-set -e
-if [ -n "$VMWARE_CREDENTIALS" ]; then
-    if [ ! -f "$VMWARE_CREDENTIALS" ]; then
-        echo "ERROR: specified credentials file not found"
-        exit 1
-    else
-        source $VMWARE_CREDENTIALS
-        if [ -z "$VMWARE_USERNAME" ]; then
-            echo '$VMWARE_USERNAME is missing'
-            exit 1
-        fi
-        if [ -z "$VMWARE_PASSWORD" ]; then
-            echo '$VMWARE_USERNAME is missing'
-            exit 1
-        fi
-        ETCD_BOOTSTRAP_FLAGS="$ETCD_BOOTSTRAP_FLAGS -vmware-username $VMWARE_USERNAME -vmware-password $VMWARE_PASSWORD"
-    fi
-fi
 
-/etcd-bootstrap -o /etcd-bootstrap.conf $ETCD_BOOTSTRAP_FLAGS
-set -a
-source /etcd-bootstrap.conf
-set +a
-exec /etcd $@
+/bootstrap.sh $ETCD_BOOTSTRAP_FLAGS
+/etcd.sh


### PR DESCRIPTION
This change allows etcd-bootstrap to be used with coreos' etcd images
from v3 onwards. This is achieved by having etcd-bootstrap output a
startup script into a volume which can then be mounted into the coreos
image and the entrypoint changed to the generated startup script.

This may be utilised in Kubernetes by running etcd-bootstrap as an
init-container, and then sharing the startup script in an emptyDir
volume.

- Splits `start-etcd.sh` into `bootstrap.sh` and `etcd.sh` to allow the
two changes to allow bootstrapping without starting etcd and starting
etcd without bootstrapping.
- Changed location of intermediary config file to /bootstrap to make
volume mounting easier.
- Move etcd binary location to ``/usr/local/bin` from `/` to match the
coreos image