### PR TITLE
Use instance IP address when registering AWS LB

### DIFF
--- a/provider/aws/lb_target_group.go
+++ b/provider/aws/lb_target_group.go
@@ -71,7 +71,7 @@ func (l LBTargetGroupRegistrationProvider) Update(instances []provider.Instance)
 	var targets []*elbv2.TargetDescription
 	for _, instance := range instances {
 		targets = append(targets, &elbv2.TargetDescription{
-			Id: aws.String(instance.InstanceID),
+			Id: aws.String(instance.PrivateIP),
 		})
 	}
 

--- a/provider/aws/lb_target_group_test.go
+++ b/provider/aws/lb_target_group_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Loadbalancer Target Group Registration Provider", func() {
 		var elbInstances []*elbv2.TargetDescription
 		for _, testInstance := range testInstances {
 			elbInstances = append(elbInstances, &elbv2.TargetDescription{
-				Id: aws.String(testInstance.InstanceID),
+				Id: aws.String(testInstance.PrivateIP),
 			})
 		}
 


### PR DESCRIPTION
When using the `registrationProvider` `route53` rather than adding the
instance ID to the target group it will instead use the instance private
ip address.  This gets around the issue of asymmetric routing when
trying to loadbalance to it's own address.

Required by https://github.com/sky-uk/core-infrastructure/issues/5592