### PR TITLE
SRV support for etcd-bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.12
+  - 1.14
 
 env:
   - GO111MODULE=on

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -30,13 +30,13 @@ const (
 // CloudInstances returns instance information for the etcd cluster from cloud APIs.
 type CloudInstances interface {
 	// GetInstances returns all the non-terminated instances that will be part of the etcd cluster.
-	GetInstances() []cloud.Instance
+	GetInstances() ([]cloud.Instance, error)
 }
 
 // CloudLocalInstance returns instance information for the local instance from cloud APIs.
 type CloudLocalInstance interface {
 	// GetLocalInstance returns the local machine instance.
-	GetLocalInstance() cloud.Instance
+	GetLocalInstance() (cloud.Instance, error)
 }
 
 type etcdCluster interface {
@@ -65,7 +65,7 @@ func (b *Bootstrapper) GenerateEtcdFlags() (string, error) {
 	}
 	if !clusterExists {
 		log.Info("No cluster found - treating as an initial node in the new cluster")
-		return b.bootstrapNewCluster(), nil
+		return b.bootstrapNewCluster()
 	}
 
 	nodeExistsInCluster, err := b.nodeExistsInCluster()
@@ -76,7 +76,7 @@ func (b *Bootstrapper) GenerateEtcdFlags() (string, error) {
 		// We treat it as a new cluster in case the cluster hasn't fully bootstrapped yet.
 		// etcd will ignore the INITIAL_* flags otherwise, so this should be safe.
 		log.Info("Node peer URL already exists - treating as an existing node in a new cluster")
-		return b.bootstrapNewCluster(), nil
+		return b.bootstrapNewCluster()
 	}
 
 	log.Info("Node does not exist yet in cluster - joining as a new node")
@@ -107,7 +107,11 @@ func (b *Bootstrapper) nodeExistsInCluster() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	localInstanceURL := peerURL(b.localInstance.GetLocalInstance().PrivateIP)
+	localInstance, err := b.localInstance.GetLocalInstance()
+	if err != nil {
+		return false, err
+	}
+	localInstanceURL := peerURL(localInstance.PrivateIP)
 
 	for _, member := range members {
 		if member.PeerURL == localInstanceURL && len(member.Name) > 0 {
@@ -118,20 +122,26 @@ func (b *Bootstrapper) nodeExistsInCluster() (bool, error) {
 	return false, nil
 }
 
-func (b *Bootstrapper) bootstrapNewCluster() string {
-	instanceURLs := b.getInstancePeerURLs()
+func (b *Bootstrapper) bootstrapNewCluster() (string, error) {
+	instanceURLs, err := b.getInstancePeerURLs()
+	if err != nil {
+		return "", err
+	}
 	return b.createEtcdConfig(newCluster, instanceURLs)
 }
 
-func (b *Bootstrapper) getInstancePeerURLs() []string {
-	instances := b.instances.GetInstances()
+func (b *Bootstrapper) getInstancePeerURLs() ([]string, error) {
+	instances, err := b.instances.GetInstances()
+	if err != nil {
+		return nil, err
+	}
 
 	var peerURLs []string
 	for _, i := range instances {
 		peerURLs = append(peerURLs, peerURL(i.PrivateIP))
 	}
 
-	return peerURLs
+	return peerURLs, nil
 }
 
 func (b *Bootstrapper) bootstrapNewNode() (string, error) {
@@ -143,7 +153,7 @@ func (b *Bootstrapper) bootstrapNewNode() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return b.createEtcdConfig(existingCluster, clusterURLs), nil
+	return b.createEtcdConfig(existingCluster, clusterURLs)
 }
 
 func (b *Bootstrapper) reconcileMembers() error {
@@ -158,7 +168,10 @@ func (b *Bootstrapper) removeOldEtcdMembers() error {
 	if err != nil {
 		return err
 	}
-	instanceURLs := b.getInstancePeerURLs()
+	instanceURLs, err := b.getInstancePeerURLs()
+	if err != nil {
+		return err
+	}
 
 	for _, memberURL := range memberURLs {
 		if !contains(instanceURLs, memberURL) {
@@ -178,7 +191,11 @@ func (b *Bootstrapper) addLocalInstanceToEtcd() error {
 	if err != nil {
 		return err
 	}
-	localInstanceURL := peerURL(b.localInstance.GetLocalInstance().PrivateIP)
+	localInstance, err := b.localInstance.GetLocalInstance()
+	if err != nil {
+		return err
+	}
+	localInstanceURL := peerURL(localInstance.PrivateIP)
 
 	if !contains(memberURLs, localInstanceURL) {
 		log.Infof("Adding local instance %s to the etcd member list", localInstanceURL)
@@ -202,26 +219,36 @@ func (b *Bootstrapper) etcdMemberPeerURLs() ([]string, error) {
 	return memberURLs, nil
 }
 
-func (b *Bootstrapper) createEtcdConfig(state clusterState, availablePeerURLs []string) string {
+func (b *Bootstrapper) createEtcdConfig(state clusterState, availablePeerURLs []string) (string, error) {
 	var envs []string
 
 	envs = append(envs, "ETCD_INITIAL_CLUSTER_STATE="+string(state))
-	initialCluster := b.constructInitialCluster(availablePeerURLs)
+	initialCluster, err := b.constructInitialCluster(availablePeerURLs)
+	if err != nil {
+		return "", err
+	}
 	envs = append(envs, fmt.Sprintf("ETCD_INITIAL_CLUSTER=%s", initialCluster))
 
-	local := b.localInstance.GetLocalInstance()
+	local, err := b.localInstance.GetLocalInstance()
+	if err != nil {
+		return "", err
+	}
 	envs = append(envs, fmt.Sprintf("ETCD_NAME=%s", local.InstanceID))
 	envs = append(envs, fmt.Sprintf("ETCD_INITIAL_ADVERTISE_PEER_URLS=%s", peerURL(local.PrivateIP)))
 	envs = append(envs, fmt.Sprintf("ETCD_LISTEN_PEER_URLS=%s", peerURL(local.PrivateIP)))
 	envs = append(envs, fmt.Sprintf("ETCD_LISTEN_CLIENT_URLS=%s,%s", clientURL(local.PrivateIP), clientURL("127.0.0.1")))
 	envs = append(envs, fmt.Sprintf("ETCD_ADVERTISE_CLIENT_URLS=%s", clientURL(local.PrivateIP)))
 
-	return strings.Join(envs, "\n") + "\n"
+	return strings.Join(envs, "\n") + "\n", nil
 }
 
-func (b *Bootstrapper) constructInitialCluster(availablePeerURLs []string) string {
+func (b *Bootstrapper) constructInitialCluster(availablePeerURLs []string) (string, error) {
+	instances, err := b.instances.GetInstances()
+	if err != nil {
+		return "", err
+	}
 	var initialCluster []string
-	for _, instance := range b.instances.GetInstances() {
+	for _, instance := range instances {
 		instancePeerURL := peerURL(instance.PrivateIP)
 		if contains(availablePeerURLs, instancePeerURL) {
 			initialCluster = append(initialCluster,
@@ -229,7 +256,7 @@ func (b *Bootstrapper) constructInitialCluster(availablePeerURLs []string) strin
 		}
 	}
 
-	return strings.Join(initialCluster, ",")
+	return strings.Join(initialCluster, ","), nil
 }
 
 func writeToFile(outputFilename string, data string) error {

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -71,8 +71,9 @@ var _ = Describe("Bootstrap", func() {
 		By("Returning an error when getting the list of etcd members")
 		etcdCluster.MockMembers.Err = fmt.Errorf("failed to get etcd members")
 		bootstrapperClient := Bootstrapper{
-			cloud: cloudProvider,
-			cluster:  etcdCluster,
+			instances:     cloudProvider,
+			localInstance: cloudProvider,
+			cluster:       etcdCluster,
 		}
 
 		_, err := bootstrapperClient.GenerateEtcdFlags()
@@ -102,8 +103,9 @@ var _ = Describe("Bootstrap", func() {
 		By("Returning an error when trying to remove an etcd member")
 		etcdCluster.MockRemoveMember.Err = fmt.Errorf("failed to remove etcd members")
 		bootstrapperClient := Bootstrapper{
-			cloud: cloudProvider,
-			cluster:  etcdCluster,
+			instances:     cloudProvider,
+			localInstance: cloudProvider,
+			cluster:       etcdCluster,
 		}
 
 		_, err := bootstrapperClient.GenerateEtcdFlags()
@@ -136,8 +138,9 @@ var _ = Describe("Bootstrap", func() {
 		By("Returning an error when attempting to list all etcd members")
 		etcdCluster.MockAddMember.Err = fmt.Errorf("failed to add etcd member")
 		bootstrapperClient := Bootstrapper{
-			cloud: cloudProvider,
-			cluster:  etcdCluster,
+			instances:     cloudProvider,
+			localInstance: cloudProvider,
+			cluster:       etcdCluster,
 		}
 
 		_, err := bootstrapperClient.GenerateEtcdFlags()
@@ -166,8 +169,9 @@ var _ = Describe("Bootstrap", func() {
 		By("Returning a list of etcd members that is empty")
 		etcdCluster.MockMembers.MembersOutput = []etcd.Member{}
 		bootstrapperClient := Bootstrapper{
-			cloud: cloudProvider,
-			cluster:  etcdCluster,
+			instances:     cloudProvider,
+			localInstance: cloudProvider,
+			cluster:       etcdCluster,
 		}
 
 		etcdFlags, err := bootstrapperClient.GenerateEtcdFlags()
@@ -217,8 +221,9 @@ var _ = Describe("Bootstrap", func() {
 			},
 		}
 		bootstrapperClient := Bootstrapper{
-			cloud: cloudProvider,
-			cluster:  etcdCluster,
+			instances:     cloudProvider,
+			localInstance: cloudProvider,
+			cluster:       etcdCluster,
 		}
 
 		etcdFlags, err := bootstrapperClient.GenerateEtcdFlags()
@@ -271,8 +276,9 @@ var _ = Describe("Bootstrap", func() {
 		By("Expecting a RemoveMember() call to be made with the old instance PeerURL")
 		etcdCluster.MockRemoveMember.ExpectedInputs = []string{"http://192.168.0.1:2380"}
 		bootstrapperClient := Bootstrapper{
-			cloud: cloudProvider,
-			cluster:  etcdCluster,
+			instances:     cloudProvider,
+			localInstance: cloudProvider,
+			cluster:       etcdCluster,
 		}
 
 		etcdFlags, err := bootstrapperClient.GenerateEtcdFlags()
@@ -321,8 +327,9 @@ var _ = Describe("Bootstrap", func() {
 			},
 		}
 		bootstrapperClient := Bootstrapper{
-			cloud: cloudProvider,
-			cluster:  etcdCluster,
+			instances:     cloudProvider,
+			localInstance: cloudProvider,
+			cluster:       etcdCluster,
 		}
 
 		etcdFlags, err := bootstrapperClient.GenerateEtcdFlags()

--- a/cloud/aws/aws_test.go
+++ b/cloud/aws/aws_test.go
@@ -44,10 +44,10 @@ var (
 )
 
 var _ = Describe("AWS Provider", func() {
-	var identityDoc ec2metadata.EC2InstanceIdentityDocument
+	var identityDoc *ec2metadata.EC2InstanceIdentityDocument
 
 	BeforeEach(func() {
-		identityDoc = ec2metadata.EC2InstanceIdentityDocument{
+		identityDoc = &ec2metadata.EC2InstanceIdentityDocument{
 			PrivateIP:  localPrivateIP,
 			InstanceID: localInstanceID,
 		}

--- a/cloud/gcp/gcp.go
+++ b/cloud/gcp/gcp.go
@@ -28,13 +28,13 @@ type Members struct {
 }
 
 // GetInstances will return the gcp etcd instances
-func (m *Members) GetInstances() []cloud.Instance {
-	return m.instances
+func (m *Members) GetInstances() ([]cloud.Instance, error) {
+	return m.instances, nil
 }
 
 // GetLocalInstance will get the gcp instance etcd bootstrap is running on
-func (m *Members) GetLocalInstance() cloud.Instance {
-	return m.instance
+func (m *Members) GetLocalInstance() (cloud.Instance, error) {
+	return m.instance, nil
 }
 
 // NewGCP returns the Members matching the cfg.

--- a/cloud/srv/srv.go
+++ b/cloud/srv/srv.go
@@ -1,0 +1,67 @@
+package srv
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/sky-uk/etcd-bootstrap/cloud"
+)
+
+const (
+	service = "etcd-bootstrap"
+	proto   = "tcp"
+	timeout = 5 * time.Second
+)
+
+// Members returns the instance information for an etcd cluster.
+type Members struct {
+	instances []cloud.Instance
+}
+
+// Resolver for looking up SRV records.
+type Resolver interface {
+	// LookupSRV is from net.LookupSRV.
+	LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error)
+}
+
+// Config is the configuration for an SRV lookup.
+type Config struct {
+	// DomainName is the domain name to use.
+	DomainName string
+	// Service is the SRV service to use.
+	Service string
+	// Resolver is the underlying SRV resolver to use.
+	// Leave nil to use net.Resolver.
+	Resolver Resolver
+}
+
+// Lookup uses the SRV record to return the members in an etcd cluster.
+func Lookup(conf *Config) (*Members, error) {
+	r := conf.Resolver
+	if r == nil {
+		r = &net.Resolver{}
+	}
+	ctx, cancelFn := context.WithTimeout(context.Background(), timeout)
+	defer cancelFn()
+	_, addrs, err := r.LookupSRV(ctx, service, proto, conf.DomainName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to lookup SRV for _%s._%s.%s: %w", service, proto, conf.DomainName, err)
+	}
+	var instances []cloud.Instance
+	for _, addr := range addrs {
+		instances = append(instances, cloud.Instance{
+			PrivateIP:  addr.Target,
+			InstanceID: fmt.Sprintf("etcd-%s", addr.Target),
+		})
+	}
+	return &Members{
+		instances: instances,
+	}, err
+}
+
+// GetInstances returns the instances inside of the SRV record.
+func (s *Members) GetInstances() []cloud.Instance {
+	return s.instances
+}

--- a/cloud/srv/srv_test.go
+++ b/cloud/srv/srv_test.go
@@ -56,21 +56,21 @@ var _ = Describe("SRV Instances", func() {
 		conf = &Config{
 			DomainName: "my-etcd-cluster.example.com",
 			Resolver:   resolver,
-			Service:    "etcd-client-ssl",
+			Service:    "etcd-server-ssl",
 		}
 	})
 
 	It("should request the correct SRV record", func() {
-		Lookup(conf)
+		New(conf).GetInstances()
 
-		Expect(resolver.receivedService).To(Equal("etcd-bootstrap"))
+		Expect(resolver.receivedService).To(Equal("etcd-server-ssl"))
 		Expect(resolver.receivedProto).To(Equal("tcp"))
 		Expect(resolver.receivedName).To(Equal("my-etcd-cluster.example.com"))
 	})
 
 	It("should return the instances in the SRV record", func() {
-		srv, _ := Lookup(conf)
-		instances := srv.GetInstances()
+		srv := New(conf)
+		instances, _ := srv.GetInstances()
 
 		Expect(instances).To(HaveLen(3))
 		Expect(instances[0].PrivateIP).To(Equal("10.10.10.1"))
@@ -79,8 +79,8 @@ var _ = Describe("SRV Instances", func() {
 	})
 
 	It("should return unique instance IDs", func() {
-		srv, _ := Lookup(conf)
-		instances := srv.GetInstances()
+		srv := New(conf)
+		instances, _ := srv.GetInstances()
 
 		Expect(instances).To(HaveLen(3))
 		Expect(instances[0].InstanceID).To(Equal("etcd-10.10.10.1"))

--- a/cloud/srv/srv_test.go
+++ b/cloud/srv/srv_test.go
@@ -1,0 +1,90 @@
+package srv
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSRV(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SRV Suite")
+}
+
+type stubResolver struct {
+	receivedService, receivedProto, receivedName string
+	sentCname                                    string
+	sentAddrs                                    []*net.SRV
+	sentErr                                      error
+}
+
+func (r *stubResolver) LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error) {
+	r.receivedService = service
+	r.receivedProto = proto
+	r.receivedName = name
+	return r.sentCname, r.sentAddrs, r.sentErr
+}
+
+var _ = Describe("SRV Instances", func() {
+	var (
+		addrs    []*net.SRV
+		resolver *stubResolver
+		conf     *Config
+	)
+
+	BeforeEach(func() {
+		addrs = []*net.SRV{
+			&net.SRV{
+				Target: "10.10.10.1",
+			},
+			&net.SRV{
+				Target: "10.10.10.2",
+			},
+			&net.SRV{
+				Target: "10.10.10.3",
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		resolver = &stubResolver{
+			sentAddrs: addrs,
+		}
+		conf = &Config{
+			DomainName: "my-etcd-cluster.example.com",
+			Resolver:   resolver,
+			Service:    "etcd-client-ssl",
+		}
+	})
+
+	It("should request the correct SRV record", func() {
+		Lookup(conf)
+
+		Expect(resolver.receivedService).To(Equal("etcd-bootstrap"))
+		Expect(resolver.receivedProto).To(Equal("tcp"))
+		Expect(resolver.receivedName).To(Equal("my-etcd-cluster.example.com"))
+	})
+
+	It("should return the instances in the SRV record", func() {
+		srv, _ := Lookup(conf)
+		instances := srv.GetInstances()
+
+		Expect(instances).To(HaveLen(3))
+		Expect(instances[0].PrivateIP).To(Equal("10.10.10.1"))
+		Expect(instances[1].PrivateIP).To(Equal("10.10.10.2"))
+		Expect(instances[2].PrivateIP).To(Equal("10.10.10.3"))
+	})
+
+	It("should return unique instance IDs", func() {
+		srv, _ := Lookup(conf)
+		instances := srv.GetInstances()
+
+		Expect(instances).To(HaveLen(3))
+		Expect(instances[0].InstanceID).To(Equal("etcd-10.10.10.1"))
+		Expect(instances[1].InstanceID).To(Equal("etcd-10.10.10.2"))
+		Expect(instances[2].InstanceID).To(Equal("etcd-10.10.10.3"))
+	})
+})

--- a/cloud/vmware/vmware.go
+++ b/cloud/vmware/vmware.go
@@ -45,13 +45,13 @@ type Members struct {
 }
 
 // GetInstances will return the vmware etcd instances
-func (m *Members) GetInstances() []cloud.Instance {
-	return m.instances
+func (m *Members) GetInstances() ([]cloud.Instance, error) {
+	return m.instances, nil
 }
 
 // GetLocalInstance will get the vmware instance etcd bootstrap is running on
-func (m *Members) GetLocalInstance() cloud.Instance {
-	return m.instance
+func (m *Members) GetLocalInstance() (cloud.Instance, error) {
+	return m.instance, nil
 }
 
 // NewVMware returns the Members this local instance belongs to.

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -71,7 +71,11 @@ func aws(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to generate etcd flags file: %v", err)
 	}
 
-	if err := registrator.Update(aws.GetInstances()); err != nil {
+	instances, err := aws.GetInstances()
+	if err != nil {
+		log.Fatalf("Failed to retrieve instances: %v", err)
+	}
+	if err := registrator.Update(instances); err != nil {
 		log.Fatalf("Failed to register etcd cluster data with cloud registration provider: %v", err)
 	}
 }
@@ -87,13 +91,10 @@ func cloudInstances(asg *aws_cloud.Members) bootstrap.CloudInstances {
 			log.Fatalf("srv-domain-name must be provided")
 		}
 		// Instead of using ASG, use SRV for looking up the instances.
-		cloudInstances, err := srv.Lookup(&srv.Config{
+		cloudInstances := srv.New(&srv.Config{
 			DomainName: srvDomainName,
 			Service:    srvService,
 		})
-		if err != nil {
-			log.Fatalf("Failed to use SRV record: %v", err)
-		}
 		return cloudInstances
 	default:
 		log.Fatalf("Unsupported cluster lookup method %q", clusterLookupMethod)

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -7,8 +7,9 @@ import (
 	"github.com/sky-uk/etcd-bootstrap/cloud"
 
 	log "github.com/sirupsen/logrus"
-	aws_provider "github.com/sky-uk/etcd-bootstrap/cloud/aws"
+	aws_cloud "github.com/sky-uk/etcd-bootstrap/cloud/aws"
 	"github.com/sky-uk/etcd-bootstrap/cloud/noop"
+	"github.com/sky-uk/etcd-bootstrap/cloud/srv"
 	"github.com/spf13/cobra"
 )
 
@@ -24,19 +25,28 @@ var (
 	route53ZoneID           string
 	dnsHostname             string
 	lbTargetGroupName       string
+	clusterLookupMethod     string
+	srvDomainName           string
+	srvService              string
 )
 
 func init() {
 	RootCmd.AddCommand(awsCmd)
 
 	awsCmd.Flags().StringVarP(&awsRegistrationProvider, "registration-provider", "r", "noop", fmt.Sprintf(
-		"automatic registration provider to use, options are: noop, route53, lb"))
+		"automatic registration provider to use, options are: noop, lb, route53"))
 	awsCmd.Flags().StringVar(&route53ZoneID, "r53-zone-id", "",
-		"route53 zone id for automatic registration (required when --registration-provider=route53)")
+		"zone id for automatic registration for registration-provider=route53")
 	awsCmd.Flags().StringVar(&dnsHostname, "dns-hostname", "",
-		"hostname to set when registering the etcd cluster with route53 (required when --registration-provider=route53)")
+		"hostname to set to the etcd cluster when registration-provider=route53")
 	awsCmd.Flags().StringVar(&lbTargetGroupName, "lb-target-group-name", "",
-		"loadbalancer target group name to use when registering the etcd cluster (required when: --registration-provider=lb)")
+		"loadbalancer target group name to use when --registration-provider=lb")
+	awsCmd.Flags().StringVar(&clusterLookupMethod, "cluster-lookup-method", "asg",
+		"method for looking up instances in the cluster, options are: asg, srv")
+	awsCmd.Flags().StringVar(&srvDomainName, "srv-domain-name", "",
+		"domain name to use for cluster-lookup-method=srv")
+	awsCmd.Flags().StringVar(&srvService, "srv-service", "etcd-bootstrap",
+		"service to use for cluster-lookup-method=srv")
 }
 
 type registrationProvider interface {
@@ -46,12 +56,13 @@ type registrationProvider interface {
 func aws(cmd *cobra.Command, args []string) {
 	registrator := initialiseAWSRegistrationProvider()
 
-	awsProvider, err := aws_provider.NewAWS()
+	aws, err := aws_cloud.NewAWS()
 	if err != nil {
 		log.Fatalf("Failed to create AWS provider: %v", err)
 	}
 
-	bootstrapper, err := bootstrap.New(awsProvider)
+	cloudInstances := cloudInstances(aws)
+	bootstrapper, err := bootstrap.New(cloudInstances, aws)
 	if err != nil {
 		log.Fatalf("Failed to create etcd bootstrapper: %v", err)
 	}
@@ -60,8 +71,33 @@ func aws(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to generate etcd flags file: %v", err)
 	}
 
-	if err := registrator.Update(awsProvider.GetInstances()); err != nil {
+	if err := registrator.Update(aws.GetInstances()); err != nil {
 		log.Fatalf("Failed to register etcd cluster data with cloud registration provider: %v", err)
+	}
+}
+
+func cloudInstances(asg *aws_cloud.Members) bootstrap.CloudInstances {
+	switch clusterLookupMethod {
+	case "asg":
+		log.Info("Using ASG for looking up cluster instances")
+		return asg
+	case "srv":
+		log.Info("Using SRV record for looking up cluster instances")
+		if srvDomainName == "" {
+			log.Fatalf("srv-domain-name must be provided")
+		}
+		// Instead of using ASG, use SRV for looking up the instances.
+		cloudInstances, err := srv.Lookup(&srv.Config{
+			DomainName: srvDomainName,
+			Service:    srvService,
+		})
+		if err != nil {
+			log.Fatalf("Failed to use SRV record: %v", err)
+		}
+		return cloudInstances
+	default:
+		log.Fatalf("Unsupported cluster lookup method %q", clusterLookupMethod)
+		return nil
 	}
 }
 
@@ -74,7 +110,7 @@ func initialiseAWSRegistrationProvider() registrationProvider {
 		checkRequiredFlag(route53ZoneID, "--r53-zone-id")
 		checkRequiredFlag(dnsHostname, "--dns-hostname")
 
-		registrator, err := aws_provider.NewRoute53RegistrationProvider(&aws_provider.Route53RegistrationProviderConfig{
+		registrator, err := aws_cloud.NewRoute53RegistrationProvider(&aws_cloud.Route53RegistrationProviderConfig{
 			ZoneID:   route53ZoneID,
 			Hostname: dnsHostname,
 		})
@@ -86,7 +122,7 @@ func initialiseAWSRegistrationProvider() registrationProvider {
 	case "lb":
 		checkRequiredFlag(lbTargetGroupName, "--lb-target-group-name")
 
-		registrator, err := aws_provider.NewLBTargetGroupRegistrationProvider(&aws_provider.LBTargetGroupRegistrationProviderConfig{
+		registrator, err := aws_cloud.NewLBTargetGroupRegistrationProvider(&aws_cloud.LBTargetGroupRegistrationProviderConfig{
 			TargetGroupName: lbTargetGroupName,
 		})
 		if err != nil {

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -25,7 +25,7 @@ var (
 	route53ZoneID           string
 	dnsHostname             string
 	lbTargetGroupName       string
-	clusterLookupMethod     string
+	instanceLookupMethod     string
 	srvDomainName           string
 	srvService              string
 )
@@ -41,12 +41,12 @@ func init() {
 		"hostname to set to the etcd cluster when registration-provider=route53")
 	awsCmd.Flags().StringVar(&lbTargetGroupName, "lb-target-group-name", "",
 		"loadbalancer target group name to use when --registration-provider=lb")
-	awsCmd.Flags().StringVar(&clusterLookupMethod, "cluster-lookup-method", "asg",
+	awsCmd.Flags().StringVar(&instanceLookupMethod, "instance-lookup-method", "asg",
 		"method for looking up instances in the cluster, options are: asg, srv")
 	awsCmd.Flags().StringVar(&srvDomainName, "srv-domain-name", "",
-		"domain name to use for cluster-lookup-method=srv")
+		"domain name to use for instance-lookup-method=srv")
 	awsCmd.Flags().StringVar(&srvService, "srv-service", "etcd-bootstrap",
-		"service to use for cluster-lookup-method=srv")
+		"service to use for instance-lookup-method=srv")
 }
 
 type registrationProvider interface {
@@ -81,7 +81,7 @@ func aws(cmd *cobra.Command, args []string) {
 }
 
 func cloudInstances(asg *aws_cloud.Members) bootstrap.CloudInstances {
-	switch clusterLookupMethod {
+	switch instanceLookupMethod {
 	case "asg":
 		log.Info("Using ASG for looking up cluster instances")
 		return asg
@@ -97,7 +97,7 @@ func cloudInstances(asg *aws_cloud.Members) bootstrap.CloudInstances {
 		})
 		return cloudInstances
 	default:
-		log.Fatalf("Unsupported cluster lookup method %q", clusterLookupMethod)
+		log.Fatalf("Unsupported cluster lookup method %q", instanceLookupMethod)
 		return nil
 	}
 }

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -25,7 +25,7 @@ var (
 	route53ZoneID           string
 	dnsHostname             string
 	lbTargetGroupName       string
-	instanceLookupMethod     string
+	instanceLookupMethod    string
 	srvDomainName           string
 	srvService              string
 )

--- a/cmd/gcp.go
+++ b/cmd/gcp.go
@@ -42,7 +42,7 @@ func gcp(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to create GCP provider: %v", err)
 	}
 
-	bootstrapper, err := bootstrap.New(gcpProvider)
+	bootstrapper, err := bootstrap.New(gcpProvider, gcpProvider)
 	if err != nil {
 		log.Fatalf("Failed to create etcd bootstrapper: %v", err)
 	}

--- a/cmd/vmware.go
+++ b/cmd/vmware.go
@@ -78,7 +78,7 @@ func vmware(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to create VMware provider: %v", err)
 	}
 
-	bootstrapper, err := bootstrap.New(vmwareProvider)
+	bootstrapper, err := bootstrap.New(vmwareProvider, vmwareProvider)
 	if err != nil {
 		log.Fatalf("Failed to create etcd bootstrapper: %v", err)
 	}

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -23,7 +23,7 @@ type Cluster struct {
 // Provider of cloud node instance information.
 type Provider interface {
 	// GetInstances returns all the non-terminated instances that will be part of the etcd cluster.
-	GetInstances() []cloud.Instance
+	GetInstances() ([]cloud.Instance, error)
 }
 
 // Member represents a node in the etcd cluster.
@@ -34,7 +34,10 @@ type Member struct {
 
 // New returns a cluster object for interacting with the etcd cluster API.
 func New(provider Provider) (*Cluster, error) {
-	instances := provider.GetInstances()
+	instances, err := provider.GetInstances()
+	if err != nil {
+		return nil, err
+	}
 
 	var endpoints []string
 	for _, instance := range instances {

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 	github.com/prometheus/client_golang v1.0.0 // indirect
-	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/soheilhy/cmux v0.1.4 // indirect
 	github.com/spf13/cobra v0.0.5
@@ -33,6 +32,5 @@ require (
 	go.uber.org/zap v1.10.0 // indirect
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	golang.org/x/tools v0.0.0-20190703212419-2214986f1668 // indirect
 	google.golang.org/api v0.7.0
 )

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 	github.com/prometheus/client_golang v1.0.0 // indirect
+	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/soheilhy/cmux v0.1.4 // indirect
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,6 @@ github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNG
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -220,8 +218,6 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c h1:97SnQk1GYRXJgvwZ8fadnxDOWfKvkNQHH3CtZntPSrM=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
-golang.org/x/tools v0.0.0-20190703212419-2214986f1668 h1:3LJOYcj2ObWSZJXX21oGIIPv5SaOoi5JkzQTWnCXRhg=
-golang.org/x/tools v0.0.0-20190703212419-2214986f1668/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.6.0/go.mod h1:btoxGiFvQNVUZQ8W08zLtrVS08CNpINPEfxXxgJL1Q4=
 google.golang.org/api v0.7.0 h1:9sdfJOzWlkqPltHAuzT2Cp+yrBeY1KRVYgms8soxMwM=

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNG
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -5,8 +5,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/route53"
-	"github.com/sky-uk/etcd-bootstrap/cloud"
-	"github.com/sky-uk/etcd-bootstrap/etcd"
 
 	"github.com/onsi/gomega"
 )
@@ -123,72 +121,4 @@ type ChangeResourceRecordSets struct {
 func (t AWSR53Client) ChangeResourceRecordSets(r *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
 	gomega.Expect(r).To(gomega.Equal(t.MockChangeResourceRecordSets.ExpectedInput))
 	return t.MockChangeResourceRecordSets.ChangeResourceRecordSetsOutput, t.MockChangeResourceRecordSets.Err
-}
-
-// EtcdCluster for mocking calls to the etcd cluster package client
-type EtcdCluster struct {
-	MockMembers      Members
-	MockRemoveMember RemoveMember
-	MockAddMember    AddMember
-}
-
-// Members sets the expected output for Members() on EtcdCluster
-type Members struct {
-	MembersOutput []etcd.Member
-	Err           error
-}
-
-// Members mocks the etcd cluster package client
-func (t EtcdCluster) Members() ([]etcd.Member, error) {
-	return t.MockMembers.MembersOutput, t.MockMembers.Err
-}
-
-// RemoveMember sets the expected input for RemoveMember() on EtcdCluster
-type RemoveMember struct {
-	ExpectedInputs []string
-	Err            error
-}
-
-// RemoveMember mocks the etcd cluster package client
-func (t EtcdCluster) RemoveMember(peerURL string) error {
-	gomega.Expect(t.MockRemoveMember.ExpectedInputs).To(gomega.ContainElement(peerURL))
-	return t.MockRemoveMember.Err
-}
-
-// AddMember sets the expected input for AddMember() on EtcdCluster
-type AddMember struct {
-	ExpectedInput string
-	Err           error
-}
-
-// AddMember mocks the etcd cluster package client
-func (t EtcdCluster) AddMember(peerURL string) error {
-	gomega.Expect(peerURL).To(gomega.Equal(t.MockAddMember.ExpectedInput))
-	return t.MockAddMember.Err
-}
-
-// CloudProvider for mocking calls to an etcd-bootstrap cloud provider
-type CloudProvider struct {
-	MockGetInstances     GetInstances
-	MockGetLocalInstance GetLocalInstance
-}
-
-// GetInstances sets the expected output for GetInstances() on CloudProvider
-type GetInstances struct {
-	GetInstancesOutput []cloud.Instance
-}
-
-// GetInstances mocks the etcd-bootstrap cloud provider
-func (t CloudProvider) GetInstances() []cloud.Instance {
-	return t.MockGetInstances.GetInstancesOutput
-}
-
-// GetLocalInstance sets the expected output for GetLocalInstance() on CloudProvider
-type GetLocalInstance struct {
-	GetLocalInstance cloud.Instance
-}
-
-// GetLocalInstance mocks the etcd-bootstrap cloud provider
-func (t CloudProvider) GetLocalInstance() cloud.Instance {
-	return t.MockGetLocalInstance.GetLocalInstance
 }


### PR DESCRIPTION
This adds new flags to the AWS bootstrapper:
- `instance-lookup-method=srv` enables SRV lookup
- `srv-domain-name=my-cluster.example.com` specifies the domain to find
the SRV record on
- `srv-service=etcd-cluster-ssl` specifies the SRV service to use

This follows RFC4122, so will look up records in
`_etcd-cluster-ssl._tcp.my-cluster.example.com`. Each target in the SRV
record is added as an instance for cluster bootstrapping and discovery.
Currently all fields other than `target` are ignored in the SRV record.

I had to change the structure of the `GetInstances()` and `GetLocalInstance()` methods to return an error, so I could move the AWS cloud logic into these methods rather than calculating them in `New`. This made it possible to reuse the AWS logic for getting the local instance information still.