### PR TITLE
Use TXT record to lookup name of each SRV target

### DIFF
--- a/cloud/srv/srv.go
+++ b/cloud/srv/srv.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/sky-uk/etcd-bootstrap/cloud"
@@ -20,10 +21,12 @@ type Members struct {
 	instances []cloud.Instance
 }
 
-// Resolver for looking up SRV records.
+// Resolver for looking up SRV records and their associated TXT record.
 type Resolver interface {
 	// LookupSRV is from net.LookupSRV.
 	LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error)
+	// LookupTXT is from net.LookupTXT.
+	LookupTXT(ctx context.Context, name string) ([]string, error)
 }
 
 // Config is the configuration for an SRV lookup.
@@ -57,12 +60,37 @@ func (m *Members) GetInstances() ([]cloud.Instance, error) {
 		}
 		var instances []cloud.Instance
 		for _, addr := range addrs {
+			name, err := m.lookupTXTName(addr.Target)
+			if err != nil {
+				return nil, fmt.Errorf("unable to lookup instance name for SRV target %s: %w", addr.Target, err)
+			}
 			instances = append(instances, cloud.Instance{
 				PrivateIP:  addr.Target,
-				InstanceID: fmt.Sprintf("etcd-%s", addr.Target),
+				InstanceID: name,
 			})
 		}
 		m.instances = instances
 	}
 	return m.instances, nil
+}
+
+// lookupTXTName looks for the name associated with the target, using RFC1464 conventions.
+func (m *Members) lookupTXTName(target string) (string, error) {
+	ctx, cancelFn := context.WithTimeout(context.Background(), timeout)
+	defer cancelFn()
+	records, err := m.Resolver.LookupTXT(ctx, target)
+	if err != nil {
+		return "", err
+	}
+	for _, record := range records {
+		split := strings.SplitN(record, "=", 2)
+		if len(split) != 2 {
+			// No '=' so skip.
+			continue
+		}
+		if split[0] == "name" {
+			return split[1], nil
+		}
+	}
+	return "", fmt.Errorf("no TXT record with `name=` attribute found for %s", target)
 }


### PR DESCRIPTION
As we need to know beforehand all of the cluster node names. For each
target in the SRV record, look up the associated TXT record for an
attribute `name=<name>` and use this (following RFC1464 convention).