### PR TITLE
Use SRV/TXT record to discover local instance info

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -111,7 +111,7 @@ func (b *Bootstrapper) nodeExistsInCluster() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	localInstanceURL := peerURL(localInstance.PrivateIP)
+	localInstanceURL := peerURL(localInstance.Endpoint)
 
 	for _, member := range members {
 		if member.PeerURL == localInstanceURL && len(member.Name) > 0 {
@@ -138,7 +138,7 @@ func (b *Bootstrapper) getInstancePeerURLs() ([]string, error) {
 
 	var peerURLs []string
 	for _, i := range instances {
-		peerURLs = append(peerURLs, peerURL(i.PrivateIP))
+		peerURLs = append(peerURLs, peerURL(i.Endpoint))
 	}
 
 	return peerURLs, nil
@@ -195,7 +195,7 @@ func (b *Bootstrapper) addLocalInstanceToEtcd() error {
 	if err != nil {
 		return err
 	}
-	localInstanceURL := peerURL(localInstance.PrivateIP)
+	localInstanceURL := peerURL(localInstance.Endpoint)
 
 	if !contains(memberURLs, localInstanceURL) {
 		log.Infof("Adding local instance %s to the etcd member list", localInstanceURL)
@@ -233,11 +233,11 @@ func (b *Bootstrapper) createEtcdConfig(state clusterState, availablePeerURLs []
 	if err != nil {
 		return "", err
 	}
-	envs = append(envs, fmt.Sprintf("ETCD_NAME=%s", local.InstanceID))
-	envs = append(envs, fmt.Sprintf("ETCD_INITIAL_ADVERTISE_PEER_URLS=%s", peerURL(local.PrivateIP)))
-	envs = append(envs, fmt.Sprintf("ETCD_LISTEN_PEER_URLS=%s", peerURL(local.PrivateIP)))
-	envs = append(envs, fmt.Sprintf("ETCD_LISTEN_CLIENT_URLS=%s,%s", clientURL(local.PrivateIP), clientURL("127.0.0.1")))
-	envs = append(envs, fmt.Sprintf("ETCD_ADVERTISE_CLIENT_URLS=%s", clientURL(local.PrivateIP)))
+	envs = append(envs, fmt.Sprintf("ETCD_NAME=%s", local.Name))
+	envs = append(envs, fmt.Sprintf("ETCD_INITIAL_ADVERTISE_PEER_URLS=%s", peerURL(local.Endpoint)))
+	envs = append(envs, fmt.Sprintf("ETCD_LISTEN_PEER_URLS=%s", peerURL(local.Endpoint)))
+	envs = append(envs, fmt.Sprintf("ETCD_LISTEN_CLIENT_URLS=%s,%s", clientURL(local.Endpoint), clientURL("127.0.0.1")))
+	envs = append(envs, fmt.Sprintf("ETCD_ADVERTISE_CLIENT_URLS=%s", clientURL(local.Endpoint)))
 
 	return strings.Join(envs, "\n") + "\n", nil
 }
@@ -249,10 +249,10 @@ func (b *Bootstrapper) constructInitialCluster(availablePeerURLs []string) (stri
 	}
 	var initialCluster []string
 	for _, instance := range instances {
-		instancePeerURL := peerURL(instance.PrivateIP)
+		instancePeerURL := peerURL(instance.Endpoint)
 		if contains(availablePeerURLs, instancePeerURL) {
 			initialCluster = append(initialCluster,
-				fmt.Sprintf("%s=%s", instance.InstanceID, instancePeerURL))
+				fmt.Sprintf("%s=%s", instance.Name, instancePeerURL))
 		}
 	}
 

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -39,8 +39,8 @@ var _ = Describe("Bootstrap", func() {
 		cloudProvider = CloudProvider{
 			MockGetLocalInstance: GetLocalInstance{
 				GetLocalInstance: cloud.Instance{
-					InstanceID: localInstanceID,
-					PrivateIP:  localPrivateIP,
+					Name:     localInstanceID,
+					Endpoint: localPrivateIP,
 				},
 			},
 		}
@@ -62,8 +62,8 @@ var _ = Describe("Bootstrap", func() {
 		By("Returning some instances including the local instance")
 		cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
 			{
-				InstanceID: localInstanceID,
-				PrivateIP:  localPrivateIP,
+				Name:     localInstanceID,
+				Endpoint: localPrivateIP,
 			},
 		}
 
@@ -83,8 +83,8 @@ var _ = Describe("Bootstrap", func() {
 		By("Returning some instances including the local instance")
 		cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
 			{
-				InstanceID: localInstanceID,
-				PrivateIP:  localPrivateIP,
+				Name:     localInstanceID,
+				Endpoint: localPrivateIP,
 			},
 		}
 
@@ -117,12 +117,12 @@ var _ = Describe("Bootstrap", func() {
 		By("Returning some instances including the local instance")
 		cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
 			{
-				InstanceID: localInstanceID,
-				PrivateIP:  localPrivateIP,
+				Name:     localInstanceID,
+				Endpoint: localPrivateIP,
 			},
 			{
-				InstanceID: "test-add-instance-id-1",
-				PrivateIP:  "192.168.0.1",
+				Name:     "test-add-instance-id-1",
+				Endpoint: "192.168.0.1",
 			},
 		}
 
@@ -152,16 +152,16 @@ var _ = Describe("Bootstrap", func() {
 		By("Returning some instances including the local instance")
 		cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
 			{
-				InstanceID: localInstanceID,
-				PrivateIP:  localPrivateIP,
+				Name:     localInstanceID,
+				Endpoint: localPrivateIP,
 			},
 			{
-				InstanceID: "test-new-cluster-instance-id-1",
-				PrivateIP:  "192.168.0.1",
+				Name:     "test-new-cluster-instance-id-1",
+				Endpoint: "192.168.0.1",
 			},
 			{
-				InstanceID: "test-new-cluster-instance-id-2",
-				PrivateIP:  "192.168.0.2",
+				Name:     "test-new-cluster-instance-id-2",
+				Endpoint: "192.168.0.2",
 			},
 		}
 
@@ -191,16 +191,16 @@ var _ = Describe("Bootstrap", func() {
 		By("Returning some instances including the local instance")
 		cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
 			{
-				InstanceID: localInstanceID,
-				PrivateIP:  localPrivateIP,
+				Name:     localInstanceID,
+				Endpoint: localPrivateIP,
 			},
 			{
-				InstanceID: "test-existing-cluster-instance-id-1",
-				PrivateIP:  "192.168.0.1",
+				Name:     "test-existing-cluster-instance-id-1",
+				Endpoint: "192.168.0.1",
 			},
 			{
-				InstanceID: "test-existing-cluster-instance-id-2",
-				PrivateIP:  "192.168.0.2",
+				Name:     "test-existing-cluster-instance-id-2",
+				Endpoint: "192.168.0.2",
 			},
 		}
 
@@ -243,16 +243,16 @@ var _ = Describe("Bootstrap", func() {
 		By("Returning some instances including the local instance")
 		cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
 			{
-				InstanceID: localInstanceID,
-				PrivateIP:  localPrivateIP,
+				Name:     localInstanceID,
+				Endpoint: localPrivateIP,
 			},
 			{
-				InstanceID: "test-existing-cluster-instance-id-2",
-				PrivateIP:  "192.168.0.2",
+				Name:     "test-existing-cluster-instance-id-2",
+				Endpoint: "192.168.0.2",
 			},
 			{
-				InstanceID: "test-existing-cluster-instance-id-3",
-				PrivateIP:  "192.168.0.3",
+				Name:     "test-existing-cluster-instance-id-3",
+				Endpoint: "192.168.0.3",
 			},
 		}
 
@@ -297,16 +297,16 @@ var _ = Describe("Bootstrap", func() {
 		By("Returning some instances including the local instance")
 		cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
 			{
-				InstanceID: localInstanceID,
-				PrivateIP:  localPrivateIP,
+				Name:     localInstanceID,
+				Endpoint: localPrivateIP,
 			},
 			{
-				InstanceID: "test-existing-cluster-partially-initialised-instance-id-1",
-				PrivateIP:  "192.168.0.1",
+				Name:     "test-existing-cluster-partially-initialised-instance-id-1",
+				Endpoint: "192.168.0.1",
 			},
 			{
-				InstanceID: "test-existing-cluster-partially-initialised-instance-id-2",
-				PrivateIP:  "192.168.0.2",
+				Name:     "test-existing-cluster-partially-initialised-instance-id-2",
+				Endpoint: "192.168.0.2",
 			},
 		}
 

--- a/cloud/aws/aws_test.go
+++ b/cloud/aws/aws_test.go
@@ -29,16 +29,16 @@ const (
 var (
 	testInstances = []cloud.Instance{
 		{
-			InstanceID: "test-instance-id-1",
-			PrivateIP:  "192.168.0.1",
+			Name:     "test-instance-id-1",
+			Endpoint: "192.168.0.1",
 		},
 		{
-			InstanceID: "test-instance-id-2",
-			PrivateIP:  "192.168.0.2",
+			Name:     "test-instance-id-2",
+			Endpoint: "192.168.0.2",
 		},
 		{
-			InstanceID: "test-instance-id-3",
-			PrivateIP:  "192.168.0.3",
+			Name:     "test-instance-id-3",
+			Endpoint: "192.168.0.3",
 		},
 	}
 )
@@ -54,10 +54,10 @@ var _ = Describe("AWS Provider", func() {
 	})
 
 	Context("interface functions", func() {
-		var awsProvider *Members
+		var awsProvider *AWS
 
 		BeforeEach(func() {
-			awsProvider = &Members{
+			awsProvider = &AWS{
 				identityDocument: identityDoc,
 				instances:        testInstances,
 			}
@@ -69,8 +69,8 @@ var _ = Describe("AWS Provider", func() {
 
 		It("run GetLocalInstance successfully", func() {
 			Expect(awsProvider.GetLocalInstance()).To(Equal(cloud.Instance{
-				InstanceID: localInstanceID,
-				PrivateIP:  localPrivateIP,
+				Name:     localInstanceID,
+				Endpoint: localPrivateIP,
 			}))
 		})
 	})
@@ -87,12 +87,12 @@ var _ = Describe("AWS Provider", func() {
 			var ec2Instances []*ec2.Instance
 			for _, testInstance := range testInstances {
 				autoscalingInstances = append(autoscalingInstances, &autoscaling.Instance{
-					InstanceId: aws.String(testInstance.InstanceID),
+					InstanceId: aws.String(testInstance.Name),
 				})
-				autoscalingInstanceIDs = append(autoscalingInstanceIDs, testInstance.InstanceID)
+				autoscalingInstanceIDs = append(autoscalingInstanceIDs, testInstance.Name)
 				ec2Instances = append(ec2Instances, &ec2.Instance{
-					InstanceId:       aws.String(testInstance.InstanceID),
-					PrivateIpAddress: aws.String(testInstance.PrivateIP),
+					InstanceId:       aws.String(testInstance.Name),
+					PrivateIpAddress: aws.String(testInstance.Endpoint),
 				})
 			}
 

--- a/cloud/aws/lb_target_group.go
+++ b/cloud/aws/lb_target_group.go
@@ -71,7 +71,7 @@ func (l LBTargetGroupRegistrationProvider) Update(instances []cloud.Instance) er
 	var targets []*elbv2.TargetDescription
 	for _, instance := range instances {
 		targets = append(targets, &elbv2.TargetDescription{
-			Id: aws.String(instance.PrivateIP),
+			Id: aws.String(instance.Endpoint),
 		})
 	}
 

--- a/cloud/aws/lb_target_group_test.go
+++ b/cloud/aws/lb_target_group_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Loadbalancer Target Group Registration Provider", func() {
 		var elbInstances []*elbv2.TargetDescription
 		for _, testInstance := range testInstances {
 			elbInstances = append(elbInstances, &elbv2.TargetDescription{
-				Id: aws.String(testInstance.PrivateIP),
+				Id: aws.String(testInstance.Endpoint),
 			})
 		}
 

--- a/cloud/aws/r53.go
+++ b/cloud/aws/r53.go
@@ -67,7 +67,7 @@ func (r Route53RegistrationProvider) Update(instances []cloud.Instance) error {
 
 	var resourceRecords []*route53.ResourceRecord
 	for _, instance := range instances {
-		resourceRecords = append(resourceRecords, &route53.ResourceRecord{Value: aws.String(instance.PrivateIP)})
+		resourceRecords = append(resourceRecords, &route53.ResourceRecord{Value: aws.String(instance.Endpoint)})
 	}
 
 	change := &route53.Change{

--- a/cloud/aws/r53_test.go
+++ b/cloud/aws/r53_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Route53 Registration Provider", func() {
 		var route53Instances []*route53.ResourceRecord
 		for _, testInstance := range testInstances {
 			route53Instances = append(route53Instances, &route53.ResourceRecord{
-				Value: aws.String(testInstance.PrivateIP),
+				Value: aws.String(testInstance.Endpoint),
 			})
 		}
 

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -1,0 +1,12 @@
+package cloud
+
+// Instance represents a cloud instance which is intended to be part of an etcd cluster.
+type Instance struct {
+	// Name is the unique name to identify this instance in an etcd cluster.
+	Name string
+
+	// Endpoint is the address to reach this instance from an etcd client.
+	// It is used to construct the peer and client URLs.
+	// It should be of the form `hostname` or `x.x.x.x`.
+	Endpoint string
+}

--- a/cloud/gcp/gcp.go
+++ b/cloud/gcp/gcp.go
@@ -76,8 +76,8 @@ func findThisInstance() (*cloud.Instance, error) {
 		return nil, fmt.Errorf("unable to retrieve local Name metadata: %v", err)
 	}
 	local := &cloud.Instance{
-		InstanceID: name,
-		PrivateIP:  ip,
+		Name:     name,
+		Endpoint: ip,
 	}
 	return local, nil
 }
@@ -120,8 +120,8 @@ func findAllInstances(client *compute.Service, cfg *Config) ([]cloud.Instance, e
 			// https://cloud.google.com/compute/docs/reference/rest/v1/instances/list
 			if len(instance.NetworkInterfaces) > 0 {
 				instances = append(instances, cloud.Instance{
-					InstanceID: instance.Name,
-					PrivateIP:  instance.NetworkInterfaces[0].NetworkIP,
+					Name:     instance.Name,
+					Endpoint: instance.NetworkInterfaces[0].NetworkIP,
 				})
 			} else {
 				return nil, fmt.Errorf("unable to find network interfaces for instance %q", instance.Name)

--- a/cloud/srv/srv.go
+++ b/cloud/srv/srv.go
@@ -15,70 +15,70 @@ const (
 	timeout = 5 * time.Second
 )
 
-// Members returns the instance information for an etcd cluster.
-type Members struct {
-	Config
-	instances []cloud.Instance
+// SRV returns the instance information for an etcd cluster using an SRV record.
+type SRV struct {
+	domainName    string
+	service       string
+	localResolver LocalResolver
+	resolver      resolver
+	instances     []cloud.Instance
+	localInstance *cloud.Instance
 }
 
-// Resolver for looking up SRV records and their associated TXT record.
-type Resolver interface {
+// LocalResolver finds the IP address associated with the local instance.
+type LocalResolver interface {
+	LookupLocalIP() (net.IP, error)
+}
+
+type resolver interface {
 	// LookupSRV is from net.LookupSRV.
 	LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error)
 	// LookupTXT is from net.LookupTXT.
 	LookupTXT(ctx context.Context, name string) ([]string, error)
+	// LookupHost is from net.LookupHost.
+	LookupHost(ctx context.Context, host string) (addrs []string, err error)
 }
 
-// Config is the configuration for an SRV lookup.
-type Config struct {
-	// DomainName is the domain name to use.
-	DomainName string
-	// Service is the SRV service to use.
-	Service string
-	// Resolver is the underlying SRV resolver to use.
-	// Leave nil to use net.Resolver.
-	Resolver Resolver
-}
-
-// New returns members that will use the SRV record to look themselves up.
-func New(conf *Config) *Members {
-	m := &Members{Config: *conf}
-	if m.Resolver == nil {
-		m.Resolver = &net.Resolver{}
+// New returns a struct that will use the SRV record to look up etcd instances.
+func New(domainName, service string, localResolver LocalResolver) *SRV {
+	return &SRV{
+		domainName:    domainName,
+		service:       service,
+		localResolver: localResolver,
+		resolver:      &net.Resolver{},
 	}
-	return m
 }
 
 // GetInstances returns the instances inside of the SRV record.
-func (m *Members) GetInstances() ([]cloud.Instance, error) {
-	if m.instances == nil {
+func (s *SRV) GetInstances() ([]cloud.Instance, error) {
+	if s.instances == nil {
 		ctx, cancelFn := context.WithTimeout(context.Background(), timeout)
 		defer cancelFn()
-		_, addrs, err := m.Resolver.LookupSRV(ctx, m.Service, proto, m.DomainName)
+		_, addrs, err := s.resolver.LookupSRV(ctx, s.service, proto, s.domainName)
 		if err != nil {
-			return nil, fmt.Errorf("unable to lookup SRV for _%s._%s.%s: %w", m.Service, proto, m.DomainName, err)
+			return nil, fmt.Errorf("unable to lookup SRV for _%s._%s.%s: %w", s.service, proto, s.domainName, err)
 		}
 		var instances []cloud.Instance
 		for _, addr := range addrs {
-			name, err := m.lookupTXTName(addr.Target)
+			name, err := s.lookupTXTName(addr.Target)
 			if err != nil {
 				return nil, fmt.Errorf("unable to lookup instance name for SRV target %s: %w", addr.Target, err)
 			}
 			instances = append(instances, cloud.Instance{
-				PrivateIP:  addr.Target,
-				InstanceID: name,
+				Endpoint: addr.Target,
+				Name:     name,
 			})
 		}
-		m.instances = instances
+		s.instances = instances
 	}
-	return m.instances, nil
+	return s.instances, nil
 }
 
 // lookupTXTName looks for the name associated with the target, using RFC1464 conventions.
-func (m *Members) lookupTXTName(target string) (string, error) {
+func (s *SRV) lookupTXTName(target string) (string, error) {
 	ctx, cancelFn := context.WithTimeout(context.Background(), timeout)
 	defer cancelFn()
-	records, err := m.Resolver.LookupTXT(ctx, target)
+	records, err := s.resolver.LookupTXT(ctx, target)
 	if err != nil {
 		return "", err
 	}
@@ -93,4 +93,54 @@ func (m *Members) lookupTXTName(target string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("no TXT record with `name=` attribute found for %s", target)
+}
+
+func (s *SRV) lookupInstanceAddresses(instances []cloud.Instance) (map[cloud.Instance][]string, error) {
+	instanceAddrs := make(map[cloud.Instance][]string)
+	for _, instance := range instances {
+		ctx, cancelFn := context.WithTimeout(context.Background(), timeout)
+		defer cancelFn()
+		addrs, err := s.resolver.LookupHost(ctx, instance.Endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("unable to resolve target %s: %w", instance, err)
+		}
+		instanceAddrs[instance] = addrs
+	}
+	return instanceAddrs, nil
+}
+
+func (s *SRV) findLocalInstance() (cloud.Instance, error) {
+	localIP, err := s.localResolver.LookupLocalIP()
+	if err != nil {
+		return cloud.Instance{}, fmt.Errorf("unable to lookup local IP: %w", err)
+	}
+	instances, err := s.GetInstances()
+	if err != nil {
+		return cloud.Instance{}, err
+	}
+	instanceAddrs, err := s.lookupInstanceAddresses(instances)
+	if err != nil {
+		return cloud.Instance{}, fmt.Errorf("unable to lookup SRV targets: %w", err)
+	}
+
+	for instance, addrs := range instanceAddrs {
+		for _, addr := range addrs {
+			if localIP.Equal(net.ParseIP(addr)) {
+				return instance, nil
+			}
+		}
+	}
+	return cloud.Instance{}, fmt.Errorf("none of the SRV targets %v resolve to local IP %v", instanceAddrs, localIP)
+}
+
+// GetLocalInstance will return the unique name and endpoint of the local instance using the SRV record.
+func (s *SRV) GetLocalInstance() (cloud.Instance, error) {
+	if s.localInstance == nil {
+		instance, err := s.findLocalInstance()
+		if err != nil {
+			return cloud.Instance{}, err
+		}
+		s.localInstance = &instance
+	}
+	return *s.localInstance, nil
 }

--- a/cloud/srv/srv_test.go
+++ b/cloud/srv/srv_test.go
@@ -14,37 +14,20 @@ func TestSRV(t *testing.T) {
 	RunSpecs(t, "SRV Suite")
 }
 
-type stubResolver struct {
-	receivedService, receivedProto, receivedName string
-	sentCname                                    string
-	sentAddrs                                    []*net.SRV
-	sentErr                                      error
-	receivedTXTName                              string
-	sentTXT                                      map[string][]string
-	sentTXTerr                                   error
-}
-
-func (r *stubResolver) LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error) {
-	r.receivedService = service
-	r.receivedProto = proto
-	r.receivedName = name
-	return r.sentCname, r.sentAddrs, r.sentErr
-}
-
-func (r *stubResolver) LookupTXT(ctx context.Context, name string) ([]string, error) {
-	r.receivedTXTName = name
-	return r.sentTXT[name], r.sentTXTerr
-}
-
 var _ = Describe("SRV Instances", func() {
 	var (
-		addrs    []*net.SRV
-		sentTXT  map[string][]string
-		resolver *stubResolver
-		conf     *Config
+		domainName, service string
+		addrs               []*net.SRV
+		sentTXTs            map[string][]string
+		sentHostAddrs       map[string][]string
+		resolver            *stubResolver
+		localResolver       *stubLocalResolver
+		srv                 *SRV
 	)
 
 	BeforeEach(func() {
+		domainName = "my-etcd-cluster.example.com"
+		service = "etcd-server-ssl"
 		addrs = []*net.SRV{
 			&net.SRV{
 				Target: "etcd-1",
@@ -56,52 +39,94 @@ var _ = Describe("SRV Instances", func() {
 				Target: "etcd-3",
 			},
 		}
-		sentTXT = make(map[string][]string)
-		sentTXT["etcd-1"] = []string{"bogus", "boz=woz", "name=i-abc1", "gbg=rrr"}
-		sentTXT["etcd-2"] = []string{"name=i-abc2"}
-		sentTXT["etcd-3"] = []string{"name=i-abc3"}
+		sentTXTs = make(map[string][]string)
+		sentTXTs["etcd-1"] = []string{"bogus", "boz=woz", "name=i-abc1", "gbg=rrr"}
+		sentTXTs["etcd-2"] = []string{"name=i-abc2"}
+		sentTXTs["etcd-3"] = []string{"name=i-abc3"}
+		sentHostAddrs = make(map[string][]string)
+		sentHostAddrs["etcd-1"] = []string{"10.10.10.1"}
+		sentHostAddrs["etcd-2"] = []string{"172.17.1.2", "10.10.10.2"}
+		sentHostAddrs["etcd-3"] = []string{"10.10.10.3"}
 	})
 
 	JustBeforeEach(func() {
 		resolver = &stubResolver{
-			sentAddrs: addrs,
-			sentTXT:   sentTXT,
+			sentAddrs:     addrs,
+			sentTXTs:      sentTXTs,
+			sentHostAddrs: sentHostAddrs,
 		}
-		conf = &Config{
-			DomainName: "my-etcd-cluster.example.com",
-			Resolver:   resolver,
-			Service:    "etcd-server-ssl",
+		localResolver = &stubLocalResolver{
+			sentIP: net.ParseIP("10.10.10.2"),
 		}
+		srv = New(domainName, service, localResolver)
+		srv.resolver = resolver
 	})
 
 	It("should request the correct SRV record", func() {
-		_, err := New(conf).GetInstances()
+		_, err := srv.GetInstances()
 		Expect(err).To(Succeed())
-
 		Expect(resolver.receivedService).To(Equal("etcd-server-ssl"))
 		Expect(resolver.receivedProto).To(Equal("tcp"))
 		Expect(resolver.receivedName).To(Equal("my-etcd-cluster.example.com"))
 	})
 
 	It("should return the instances in the SRV record", func() {
-		srv := New(conf)
 		instances, err := srv.GetInstances()
 		Expect(err).To(Succeed())
-
 		Expect(instances).To(HaveLen(3))
-		Expect(instances[0].PrivateIP).To(Equal("etcd-1"))
-		Expect(instances[1].PrivateIP).To(Equal("etcd-2"))
-		Expect(instances[2].PrivateIP).To(Equal("etcd-3"))
+		Expect(instances[0].Endpoint).To(Equal("etcd-1"))
+		Expect(instances[1].Endpoint).To(Equal("etcd-2"))
+		Expect(instances[2].Endpoint).To(Equal("etcd-3"))
 	})
 
 	It("should return unique instance IDs", func() {
-		srv := New(conf)
 		instances, err := srv.GetInstances()
 		Expect(err).To(Succeed())
-
 		Expect(instances).To(HaveLen(3))
-		Expect(instances[0].InstanceID).To(Equal("i-abc1"))
-		Expect(instances[1].InstanceID).To(Equal("i-abc2"))
-		Expect(instances[2].InstanceID).To(Equal("i-abc3"))
+		Expect(instances[0].Name).To(Equal("i-abc1"))
+		Expect(instances[1].Name).To(Equal("i-abc2"))
+		Expect(instances[2].Name).To(Equal("i-abc3"))
+	})
+
+	It("should discover its local instance information via the SRV record", func() {
+		local, err := srv.GetLocalInstance()
+		Expect(err).To(Succeed())
+		Expect(local.Name).To(Equal("i-abc2"))
+		Expect(local.Endpoint).To(Equal("etcd-2"))
 	})
 })
+
+type stubResolver struct {
+	receivedService, receivedProto, receivedName string
+	sentCname                                    string
+	sentAddrs                                    []*net.SRV
+	sentErr                                      error
+	sentTXTs                                     map[string][]string
+	sentTXTerr                                   error
+	sentHostAddrs                                map[string][]string
+	sentHostErr                                  error
+}
+
+func (r *stubResolver) LookupSRV(ctx context.Context, service, proto, name string) (cname string, addrs []*net.SRV, err error) {
+	r.receivedService = service
+	r.receivedProto = proto
+	r.receivedName = name
+	return r.sentCname, r.sentAddrs, r.sentErr
+}
+
+func (r *stubResolver) LookupTXT(ctx context.Context, name string) ([]string, error) {
+	return r.sentTXTs[name], r.sentTXTerr
+}
+
+func (r *stubResolver) LookupHost(ctx context.Context, host string) (addrs []string, err error) {
+	return r.sentHostAddrs[host], r.sentHostErr
+}
+
+type stubLocalResolver struct {
+	sentIP  net.IP
+	sentErr error
+}
+
+func (r *stubLocalResolver) LookupLocalIP() (net.IP, error) {
+	return r.sentIP, r.sentErr
+}

--- a/cloud/types.go
+++ b/cloud/types.go
@@ -1,7 +1,0 @@
-package cloud
-
-// Instance represents a cloud instance which is intended to be part of an etcd cluster.
-type Instance struct {
-	InstanceID string
-	PrivateIP  string
-}

--- a/cloud/vmware/vmware.go
+++ b/cloud/vmware/vmware.go
@@ -115,8 +115,8 @@ func findAllInstances(ctx context.Context, c *govmomi.Client, env, role string) 
 	for _, vm := range matched {
 		if vm.Summary.Runtime.PowerState == vmware_types.VirtualMachinePowerStatePoweredOn {
 			instances = append(instances, cloud.Instance{
-				InstanceID: vm.Config.Name,
-				PrivateIP:  vm.Summary.Guest.IpAddress,
+				Name:     vm.Config.Name,
+				Endpoint: vm.Summary.Guest.IpAddress,
 			})
 		}
 	}
@@ -137,10 +137,10 @@ func matchesTag(vm mo.VirtualMachine, tag string, match string) bool {
 
 func findThisInstance(cfg *Config, instances []cloud.Instance) (*cloud.Instance, error) {
 	for _, instance := range instances {
-		if strings.Contains(cfg.VMName, instance.InstanceID) {
+		if strings.Contains(cfg.VMName, instance.Name) {
 			return &cloud.Instance{
-				InstanceID: instance.InstanceID,
-				PrivateIP:  instance.PrivateIP,
+				Name:     instance.Name,
+				Endpoint: instance.Endpoint,
 			}, nil
 		}
 	}

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -41,7 +41,7 @@ func New(provider Provider) (*Cluster, error) {
 
 	var endpoints []string
 	for _, instance := range instances {
-		endpoints = append(endpoints, fmt.Sprintf("http://%s:2379", instance.PrivateIP))
+		endpoints = append(endpoints, fmt.Sprintf("http://%s:2379", instance.Endpoint))
 	}
 
 	c, err := client.New(client.Config{Endpoints: endpoints})


### PR DESCRIPTION
This is required so the local etcd knows its name and peerURL/clientURL.