### PR TITLE
Fix advertise URLs being different to the local IP

### DIFF
--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -20,89 +20,94 @@ func TestBootstrap(t *testing.T) {
 
 var _ = Describe("Bootstrap", func() {
 	var (
-		cloudProvider   *CloudProvider
-		etcdCluster     *MockEtcdCluster
-		bootstrapper    *Bootstrapper
-		localPrivateIP  string
-		localInstanceID string
-		localPeerURL    string
-		localClientURL  string
+		cloudAPIMock            *CloudAPIMock
+		etcdAPIMock             *EtcdAPIMock
+		bootstrapper            *Bootstrapper
+		localEndpoint           string
+		localIP                 string
+		localInstanceID         string
+		localListenPeerURL      string
+		localListenClientURL    string
+		localAdvertisePeerURL   string
+		localAdvertiseClientURL string
 	)
 
 	BeforeEach(func() {
-		localPrivateIP = "192.168.0.100"
+		localEndpoint = "test-local-endpoint"
+		localIP = "192.168.100.1"
 		localInstanceID = "test-local-instance"
-		localPeerURL = fmt.Sprintf("http://%v:2380", localPrivateIP)
-		localClientURL = fmt.Sprintf("http://%v:2379", localPrivateIP)
+		localAdvertisePeerURL = fmt.Sprintf("http://%v:2380", localEndpoint)
+		localAdvertiseClientURL = fmt.Sprintf("http://%v:2379", localEndpoint)
+		localListenPeerURL = fmt.Sprintf("http://%v:2380", localIP)
+		localListenClientURL = fmt.Sprintf("http://%v:2379", localIP)
 	})
 
 	JustBeforeEach(func() {
-		cloudProvider = &CloudProvider{
-			MockGetInstances: &GetInstances{},
-			MockGetLocalInstance: &GetLocalInstance{
+		cloudAPIMock = &CloudAPIMock{
+			GetInstancesMock: &GetInstances{},
+			GetLocalInstanceMock: &GetLocalInstance{
 				GetLocalInstance: cloud.Instance{
 					Name:     localInstanceID,
-					Endpoint: localPrivateIP,
+					Endpoint: localEndpoint,
 				},
 			},
-		}
-		etcdCluster = &MockEtcdCluster{
-			MockMembers: &Members{},
-			MockAddMember: &AddMember{
-				ExpectedInput: localPeerURL,
+			GetLocalIPMock: &GetLocalIP{
+				LocalIP: localIP,
 			},
-			MockRemoveMember: &RemoveMember{},
+		}
+		etcdAPIMock = &EtcdAPIMock{
+			MembersMock:      &Members{},
+			AddMemberMock:    &AddMember{},
+			RemoveMemberMock: &RemoveMember{},
 		}
 		bootstrapper = &Bootstrapper{
-			instances:     cloudProvider,
-			localInstance: cloudProvider,
-			cluster:       etcdCluster,
-			protocol:      "http",
+			cloudAPI: cloudAPIMock,
+			etcdAPI:  etcdAPIMock,
+			protocol: "http",
 		}
 	})
 
 	It("helper functions work", func() {
-		Expect(bootstrapper.peerURL(localPrivateIP)).To(Equal(localPeerURL))
-		Expect(bootstrapper.clientURL(localPrivateIP)).To(Equal(localClientURL))
+		Expect(bootstrapper.peerURL(localIP)).To(Equal(localListenPeerURL))
+		Expect(bootstrapper.clientURL(localIP)).To(Equal(localListenClientURL))
 	})
 
 	It("fails when it cannot get etcd members", func() {
-		By("Returning some instances including the local instance")
-		cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
+		cloudAPIMock.GetInstancesMock.GetInstancesOutput = []cloud.Instance{
 			{
 				Name:     localInstanceID,
-				Endpoint: localPrivateIP,
+				Endpoint: localEndpoint,
 			},
 		}
-
-		By("Returning an error when getting the list of etcd members")
-		etcdCluster.MockMembers.Err = fmt.Errorf("failed to get etcd members")
+		etcdAPIMock.MembersMock.Err = fmt.Errorf("failed to get etcd members")
 		_, err := bootstrapper.GenerateEtcdFlags()
 		Expect(err).To(Not(Succeed()))
 	})
 
 	It("does not fail when it cannot remove member", func() {
-		By("Returning some instances including the local instance")
-		cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
+		cloudAPIMock.GetInstancesMock.GetInstancesOutput = []cloud.Instance{
 			{
 				Name:     localInstanceID,
-				Endpoint: localPrivateIP,
+				Endpoint: localEndpoint,
 			},
 		}
-
-		By("Returning an etcd member list requiring an update")
-		etcdCluster.MockMembers.MembersOutput = []etcd.Member{
+		etcdAPIMock.MembersMock.MembersOutput = []etcd.Member{
+			{
+				Name:    localInstanceID,
+				PeerURL: localAdvertisePeerURL,
+			},
 			{
 				Name:    "test-remove-instance-id-1",
-				PeerURL: "http://192.168.0.1:2380",
+				PeerURL: "http://etcd-remove-me:2380",
 			},
 		}
 
 		By("Expecting to receive a call to remove a test instance")
-		etcdCluster.MockRemoveMember.ExpectedInputs = []string{"http://192.168.0.1:2380"}
+		nameToRemove := "test-remove-instance-id-1"
+		etcdAPIMock.RemoveMemberMock.ExpectedInput = &nameToRemove
 
 		By("Returning an error when trying to remove an etcd member")
-		etcdCluster.MockRemoveMember.Err = fmt.Errorf("failed to remove etcd members")
+		etcdAPIMock.RemoveMemberMock.Err = fmt.Errorf("failed to remove etcd members")
 		_, err := bootstrapper.GenerateEtcdFlags()
 
 		By("Do not fail as it may be down to an etcd quorum issue")
@@ -111,212 +116,238 @@ var _ = Describe("Bootstrap", func() {
 
 	It("fails when it cannot add etcd member", func() {
 		By("Returning some instances including the local instance")
-		cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
+		cloudAPIMock.GetInstancesMock.GetInstancesOutput = []cloud.Instance{
 			{
 				Name:     localInstanceID,
-				Endpoint: localPrivateIP,
+				Endpoint: localEndpoint,
 			},
 			{
 				Name:     "test-add-instance-id-1",
-				Endpoint: "192.168.0.1",
+				Endpoint: "endpoint-1",
 			},
 		}
 
 		By("Returning an etcd member list requiring an update")
-		etcdCluster.MockMembers.MembersOutput = []etcd.Member{
+		etcdAPIMock.MembersMock.MembersOutput = []etcd.Member{
 			{
 				Name:    "test-add-instance-id-1",
-				PeerURL: "http://192.168.0.1:2380",
+				PeerURL: "http://endopoint-1:2380",
 			},
 		}
 
 		By("Returning an error when attempting to list all etcd members")
-		etcdCluster.MockAddMember.Err = fmt.Errorf("failed to add etcd member")
+		etcdAPIMock.AddMemberMock.ExpectedInput = &localAdvertisePeerURL
+		etcdAPIMock.AddMemberMock.Err = fmt.Errorf("failed to add etcd member")
 		_, err := bootstrapper.GenerateEtcdFlags()
 
 		By("Do not fail as it may be down to an etcd quorum issue")
 		Expect(err).ToNot(BeNil())
 	})
 
-	It("new cluster", func() {
-		By("Returning some instances including the local instance")
-		cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
-			{
-				Name:     localInstanceID,
-				Endpoint: localPrivateIP,
-			},
-			{
-				Name:     "test-new-cluster-instance-id-1",
-				Endpoint: "192.168.0.1",
-			},
-			{
-				Name:     "test-new-cluster-instance-id-2",
-				Endpoint: "192.168.0.2",
-			},
-		}
+	Describe("new cluster", func() {
+		JustBeforeEach(func() {
+			By("Return a cluster of instances including the local instance")
+			cloudAPIMock.GetInstancesMock.GetInstancesOutput = []cloud.Instance{
+				{
+					Name:     localInstanceID,
+					Endpoint: localEndpoint,
+				},
+				{
+					Name:     "test-new-cluster-instance-id-1",
+					Endpoint: "test-new-cluster-endpoint-1",
+				},
+				{
+					Name:     "test-new-cluster-instance-id-2",
+					Endpoint: "test-new-cluster-endpoint-2",
+				},
+			}
 
-		By("Returning a list of etcd members that is empty")
-		etcdCluster.MockMembers.MembersOutput = []etcd.Member{}
-		etcdFlags, err := bootstrapper.GenerateEtcdFlags()
-		flags := strings.Split(etcdFlags, "\n")
-		Expect(err).To(BeNil())
-		Expect(flags).To(ContainElement("ETCD_INITIAL_CLUSTER_STATE=new"))
-		Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_INITIAL_CLUSTER=%v=%v,"+
-			"test-new-cluster-instance-id-1=http://192.168.0.1:2380,"+
-			"test-new-cluster-instance-id-2=http://192.168.0.2:2380", localInstanceID, localPeerURL)))
-		Expect(flags).To(ContainElement("ETCD_NAME=" + localInstanceID))
-		Expect(flags).To(ContainElement("ETCD_INITIAL_ADVERTISE_PEER_URLS=" + localPeerURL))
-		Expect(flags).To(ContainElement("ETCD_LISTEN_PEER_URLS=" + localPeerURL))
-		Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_LISTEN_CLIENT_URLS=%v,%v", localClientURL, bootstrapper.clientURL("127.0.0.1"))))
-		Expect(flags).To(ContainElement("ETCD_ADVERTISE_CLIENT_URLS=" + localClientURL))
+			By("And return an empty list of etcd members")
+			etcdAPIMock.MembersMock.MembersOutput = []etcd.Member{}
+		})
+
+		It("should create etcd flags for initializing a new cluster", func() {
+			etcdFlags, err := bootstrapper.GenerateEtcdFlags()
+			flags := strings.Split(etcdFlags, "\n")
+			Expect(err).To(BeNil())
+			Expect(flags).To(ContainElement("ETCD_INITIAL_CLUSTER_STATE=new"))
+			Expect(flags).To(ContainElement(
+				fmt.Sprintf("ETCD_INITIAL_CLUSTER=%s=%s,%s=%s,%s=%s",
+					localInstanceID, localAdvertisePeerURL,
+					"test-new-cluster-instance-id-1", "http://test-new-cluster-endpoint-1:2380",
+					"test-new-cluster-instance-id-2", "http://test-new-cluster-endpoint-2:2380")))
+			Expect(flags).To(ContainElement("ETCD_NAME=" + localInstanceID))
+			Expect(flags).To(ContainElement("ETCD_INITIAL_ADVERTISE_PEER_URLS=" + localAdvertisePeerURL))
+			Expect(flags).To(ContainElement("ETCD_ADVERTISE_CLIENT_URLS=" + localAdvertiseClientURL))
+			Expect(flags).To(ContainElement("ETCD_LISTEN_PEER_URLS=" + localListenPeerURL))
+			Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_LISTEN_CLIENT_URLS=%v,%v",
+				localListenClientURL, bootstrapper.clientURL("127.0.0.1"))))
+		})
 	})
 
-	It("an existing cluster", func() {
-		By("Returning some instances including the local instance")
-		cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
-			{
-				Name:     localInstanceID,
-				Endpoint: localPrivateIP,
-			},
-			{
-				Name:     "test-existing-cluster-instance-id-1",
-				Endpoint: "192.168.0.1",
-			},
-			{
-				Name:     "test-existing-cluster-instance-id-2",
-				Endpoint: "192.168.0.2",
-			},
-		}
+	Describe("an existing cluster", func() {
+		JustBeforeEach(func() {
+			By("Returning some instances including the local instance")
+			cloudAPIMock.GetInstancesMock.GetInstancesOutput = []cloud.Instance{
+				{
+					Name:     localInstanceID,
+					Endpoint: localEndpoint,
+				},
+				{
+					Name:     "test-existing-cluster-instance-id-1",
+					Endpoint: "endpoint-1",
+				},
+				{
+					Name:     "test-existing-cluster-instance-id-2",
+					Endpoint: "endpoint-2",
+				},
+			}
 
-		By("Returning a list of etcd members that contains too many members but does not include the local instance")
-		etcdCluster.MockMembers.MembersOutput = []etcd.Member{
-			{
-				Name:    localInstanceID,
-				PeerURL: localPeerURL,
-			},
-			{
-				Name:    "test-existing-cluster-instance-id-1",
-				PeerURL: "http://192.168.0.1:2380",
-			},
-			{
-				Name:    "test-existing-cluster-instance-id-2",
-				PeerURL: "http://192.168.0.2:2380",
-			},
-		}
+			By("And returning a list of etcd members that includes all of the instances")
+			etcdAPIMock.MembersMock.MembersOutput = []etcd.Member{
+				{
+					Name:    localInstanceID,
+					PeerURL: localListenPeerURL,
+				},
+				{
+					Name:    "test-existing-cluster-instance-id-1",
+					PeerURL: "http://test-existing-cluster-endpoint-1:2380",
+				},
+				{
+					Name:    "test-existing-cluster-instance-id-2",
+					PeerURL: "http://test-existing-cluster-endpoint-2:2380",
+				},
+			}
+		})
 
-		etcdFlags, err := bootstrapper.GenerateEtcdFlags()
-		flags := strings.Split(etcdFlags, "\n")
-		Expect(err).To(BeNil())
-		Expect(flags).To(ContainElement("ETCD_INITIAL_CLUSTER_STATE=new"))
-		Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_INITIAL_CLUSTER=%v=%v,"+
-			"test-existing-cluster-instance-id-1=http://192.168.0.1:2380,"+
-			"test-existing-cluster-instance-id-2=http://192.168.0.2:2380", localInstanceID, localPeerURL)))
-		Expect(flags).To(ContainElement("ETCD_NAME=" + localInstanceID))
-		Expect(flags).To(ContainElement("ETCD_INITIAL_ADVERTISE_PEER_URLS=" + localPeerURL))
-		Expect(flags).To(ContainElement("ETCD_LISTEN_PEER_URLS=" + localPeerURL))
-		Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_LISTEN_CLIENT_URLS=%v,%v", localClientURL, bootstrapper.clientURL("127.0.0.1"))))
-		Expect(flags).To(ContainElement("ETCD_ADVERTISE_CLIENT_URLS=" + localClientURL))
+		It("should create etcd flags for joining an existing cluster", func() {
+			etcdFlags, err := bootstrapper.GenerateEtcdFlags()
+			flags := strings.Split(etcdFlags, "\n")
+			Expect(err).To(BeNil())
+			Expect(flags).To(ContainElement("ETCD_INITIAL_CLUSTER_STATE=new"))
+			Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_INITIAL_CLUSTER=%s=%s,%s=%s,%s=%s",
+				localInstanceID, localAdvertisePeerURL,
+				"test-existing-cluster-instance-id-1", "http://endpoint-1:2380",
+				"test-existing-cluster-instance-id-2", "http://endpoint-2:2380")))
+			Expect(flags).To(ContainElement("ETCD_NAME=" + localInstanceID))
+			Expect(flags).To(ContainElement("ETCD_INITIAL_ADVERTISE_PEER_URLS=" + localAdvertisePeerURL))
+			Expect(flags).To(ContainElement("ETCD_ADVERTISE_CLIENT_URLS=" + localAdvertiseClientURL))
+			Expect(flags).To(ContainElement("ETCD_LISTEN_PEER_URLS=" + localListenPeerURL))
+			Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_LISTEN_CLIENT_URLS=%v,%v",
+				localListenClientURL, bootstrapper.clientURL("127.0.0.1"))))
+		})
 	})
 
-	It("an existing cluster where a node needs replacing", func() {
-		By("Returning some instances including the local instance")
-		cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
-			{
-				Name:     localInstanceID,
-				Endpoint: localPrivateIP,
-			},
-			{
-				Name:     "test-existing-cluster-instance-id-2",
-				Endpoint: "192.168.0.2",
-			},
-			{
-				Name:     "test-existing-cluster-instance-id-3",
-				Endpoint: "192.168.0.3",
-			},
-		}
+	Describe("an existing cluster where a node needs replacing", func() {
+		JustBeforeEach(func() {
+			By("Returning some instances including the local instance")
+			cloudAPIMock.GetInstancesMock.GetInstancesOutput = []cloud.Instance{
+				{
+					Name:     localInstanceID,
+					Endpoint: localEndpoint,
+				},
+				{
+					Name:     "test-existing-cluster-instance-id-2",
+					Endpoint: "endpoint-2",
+				},
+				{
+					Name:     "test-existing-cluster-instance-id-3",
+					Endpoint: "endpoint-3",
+				},
+			}
 
-		By("Returning a list of etcd members that contains too many members but does not include the local instance")
-		etcdCluster.MockMembers.MembersOutput = []etcd.Member{
-			{
-				Name:    "test-existing-cluster-old-instance-id-1",
-				PeerURL: "http://192.168.0.1:2380",
-			},
-			{
-				Name:    "test-existing-cluster-instance-id-2",
-				PeerURL: "http://192.168.0.2:2380",
-			},
-			{
-				Name:    "test-existing-cluster-instance-id-3",
-				PeerURL: "http://192.168.0.3:2380",
-			},
-		}
+			By("Returning a list of etcd members that contains too many members but does not include the local instance")
+			etcdAPIMock.MembersMock.MembersOutput = []etcd.Member{
+				{
+					Name:    "test-existing-cluster-old-instance-id-1",
+					PeerURL: "http://endpoint-1:2380",
+				},
+				{
+					Name:    "test-existing-cluster-instance-id-2",
+					PeerURL: "http://endpoint-2:2380",
+				},
+				{
+					Name:    "test-existing-cluster-instance-id-3",
+					PeerURL: "http://endpoint-3:2380",
+				},
+			}
+		})
 
-		By("Expecting a RemoveMember() call to be made with the old instance PeerURL")
-		etcdCluster.MockRemoveMember.ExpectedInputs = []string{"http://192.168.0.1:2380"}
-
-		etcdFlags, err := bootstrapper.GenerateEtcdFlags()
-		flags := strings.Split(etcdFlags, "\n")
-		Expect(err).To(BeNil())
-		Expect(flags).To(ContainElement("ETCD_INITIAL_CLUSTER_STATE=existing"))
-		Expect(flags).To(ContainElement("ETCD_INITIAL_CLUSTER=test-existing-cluster-instance-id-2=http://192.168.0.2:2380," +
-			"test-existing-cluster-instance-id-3=http://192.168.0.3:2380"))
-		Expect(flags).To(ContainElement("ETCD_NAME=" + localInstanceID))
-		Expect(flags).To(ContainElement("ETCD_INITIAL_ADVERTISE_PEER_URLS=" + localPeerURL))
-		Expect(flags).To(ContainElement("ETCD_LISTEN_PEER_URLS=" + localPeerURL))
-		Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_LISTEN_CLIENT_URLS=%v,%v", localClientURL, bootstrapper.clientURL("127.0.0.1"))))
-		Expect(flags).To(ContainElement("ETCD_ADVERTISE_CLIENT_URLS=" + localClientURL))
+		It("should remove the prior node and add the local node", func() {
+			oldInstanceID := "test-existing-cluster-old-instance-id-1"
+			etcdAPIMock.RemoveMemberMock.ExpectedInput = &oldInstanceID
+			etcdAPIMock.AddMemberMock.ExpectedInput = &localAdvertisePeerURL
+			etcdFlags, err := bootstrapper.GenerateEtcdFlags()
+			Expect(err).To(BeNil())
+			Expect(etcdAPIMock.RemoveMemberMock.Called).To(BeTrue())
+			Expect(etcdAPIMock.AddMemberMock.Called).To(BeTrue())
+			flags := strings.Split(etcdFlags, "\n")
+			Expect(flags).To(ContainElement("ETCD_INITIAL_CLUSTER_STATE=existing"))
+			Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_INITIAL_CLUSTER=%s=%s,%s=%s",
+				"test-existing-cluster-instance-id-2", "http://endpoint-2:2380",
+				"test-existing-cluster-instance-id-3", "http://endpoint-3:2380")))
+			Expect(flags).To(ContainElement("ETCD_NAME=" + localInstanceID))
+			Expect(flags).To(ContainElement("ETCD_INITIAL_ADVERTISE_PEER_URLS=" + localAdvertisePeerURL))
+			Expect(flags).To(ContainElement("ETCD_ADVERTISE_CLIENT_URLS=" + localAdvertiseClientURL))
+			Expect(flags).To(ContainElement("ETCD_LISTEN_PEER_URLS=" + localListenPeerURL))
+			Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_LISTEN_CLIENT_URLS=%v,%v", localListenClientURL, bootstrapper.clientURL("127.0.0.1"))))
+		})
 	})
 
-	It("an existing cluster when partially initialised", func() {
-		By("Returning some instances including the local instance")
-		cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
-			{
-				Name:     localInstanceID,
-				Endpoint: localPrivateIP,
-			},
-			{
-				Name:     "test-existing-cluster-partially-initialised-instance-id-1",
-				Endpoint: "192.168.0.1",
-			},
-			{
-				Name:     "test-existing-cluster-partially-initialised-instance-id-2",
-				Endpoint: "192.168.0.2",
-			},
-		}
+	Describe("an existing cluster that is partially initialised", func() {
+		JustBeforeEach(func() {
+			By("Returning some instances including the local instance")
+			cloudAPIMock.GetInstancesMock.GetInstancesOutput = []cloud.Instance{
+				{
+					Name:     localInstanceID,
+					Endpoint: localEndpoint,
+				},
+				{
+					Name:     "test-existing-cluster-partially-initialised-instance-id-1",
+					Endpoint: "endpoint-1",
+				},
+				{
+					Name:     "test-existing-cluster-partially-initialised-instance-id-2",
+					Endpoint: "endpoint-2",
+				},
+			}
 
-		By("Returning a list of etcd members that contains too many members but does not include the local instance")
-		etcdCluster.MockMembers.MembersOutput = []etcd.Member{
-			{
-				Name:    "",
-				PeerURL: localPeerURL,
-			},
-			{
-				Name:    "test-existing-cluster-partially-initialised-instance-id-1",
-				PeerURL: "http://192.168.0.1:2380",
-			},
-			{
-				Name:    "test-existing-cluster-partially-initialised-instance-id-2",
-				PeerURL: "http://192.168.0.2:2380",
-			},
-		}
+			By("Returning a list of etcd members that contains the local instance as partially initialised")
+			etcdAPIMock.MembersMock.MembersOutput = []etcd.Member{
+				{
+					// Name will be blank after adding the peerURL until the instance registers itself.
+					Name:    "",
+					PeerURL: localAdvertisePeerURL,
+				},
+				{
+					Name:    "test-existing-cluster-partially-initialised-instance-id-1",
+					PeerURL: "http://endpoint-1:2380",
+				},
+				{
+					Name:    "test-existing-cluster-partially-initialised-instance-id-2",
+					PeerURL: "http://endpoint-2:2380",
+				},
+			}
+		})
 
-		etcdFlags, err := bootstrapper.GenerateEtcdFlags()
-		flags := strings.Split(etcdFlags, "\n")
-		Expect(err).To(BeNil())
+		It("should add the local instance and generate etcd flags including the local instance", func() {
+			etcdFlags, err := bootstrapper.GenerateEtcdFlags()
+			Expect(err).To(BeNil())
 
-		By("Joining the existing cluster as the node has not initialised fully yet")
-		Expect(flags).To(ContainElement("ETCD_INITIAL_CLUSTER_STATE=existing"))
-		Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_INITIAL_CLUSTER=%v=%v,"+
-			"test-existing-cluster-partially-initialised-instance-id-1=http://192.168.0.1:2380,"+
-			"test-existing-cluster-partially-initialised-instance-id-2=http://192.168.0.2:2380", localInstanceID, localPeerURL)))
-		Expect(flags).To(ContainElement("ETCD_NAME=" + localInstanceID))
-		Expect(flags).To(ContainElement("ETCD_INITIAL_ADVERTISE_PEER_URLS=" + localPeerURL))
-		Expect(flags).To(ContainElement("ETCD_LISTEN_PEER_URLS=" + localPeerURL))
-		Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_LISTEN_CLIENT_URLS=%v,%v", localClientURL, bootstrapper.clientURL("127.0.0.1"))))
-		Expect(flags).To(ContainElement("ETCD_ADVERTISE_CLIENT_URLS=" + localClientURL))
+			flags := strings.Split(etcdFlags, "\n")
+			Expect(flags).To(ContainElement("ETCD_INITIAL_CLUSTER_STATE=existing"))
+			Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_INITIAL_CLUSTER=%s=%s,%s=%s",
+				"test-existing-cluster-partially-initialised-instance-id-1", "http://endpoint-1:2380",
+				"test-existing-cluster-partially-initialised-instance-id-2", "http://endpoint-2:2380")))
+			Expect(flags).To(ContainElement("ETCD_NAME=" + localInstanceID))
+			Expect(flags).To(ContainElement("ETCD_INITIAL_ADVERTISE_PEER_URLS=" + localAdvertisePeerURL))
+			Expect(flags).To(ContainElement("ETCD_ADVERTISE_CLIENT_URLS=" + localAdvertiseClientURL))
+			Expect(flags).To(ContainElement("ETCD_LISTEN_PEER_URLS=" + localListenPeerURL))
+			Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_LISTEN_CLIENT_URLS=%v,%v", localListenClientURL, bootstrapper.clientURL("127.0.0.1"))))
+		})
 	})
 
-	Describe("TLS", func() {
+	Describe("TLS new cluster", func() {
 		var (
 			serverCA   = "server-ca.pem"
 			serverCert = "server.pem"
@@ -327,44 +358,46 @@ var _ = Describe("Bootstrap", func() {
 		)
 
 		BeforeEach(func() {
-			localPeerURL = fmt.Sprintf("https://%v:2380", localPrivateIP)
-			localClientURL = fmt.Sprintf("https://%v:2379", localPrivateIP)
+			localAdvertisePeerURL = fmt.Sprintf("https://%v:2380", localEndpoint)
+			localAdvertiseClientURL = fmt.Sprintf("https://%v:2379", localEndpoint)
+			localListenPeerURL = fmt.Sprintf("https://%v:2380", localIP)
+			localListenClientURL = fmt.Sprintf("https://%v:2379", localIP)
 		})
 
 		JustBeforeEach(func() {
 			WithTLS(serverCA, serverCert, serverKey, peerCA, peerCert, peerKey)(bootstrapper)
-		})
-
-		It("adds the required TLS flags", func() {
-			cloudProvider.MockGetInstances.GetInstancesOutput = []cloud.Instance{
+			cloudAPIMock.GetInstancesMock.GetInstancesOutput = []cloud.Instance{
 				{
 					Name:     localInstanceID,
-					Endpoint: localPrivateIP,
+					Endpoint: localEndpoint,
 				},
 				{
 					Name:     "test-new-cluster-instance-id-1",
-					Endpoint: "192.168.0.1",
+					Endpoint: "endpoint-1",
 				},
 				{
 					Name:     "test-new-cluster-instance-id-2",
-					Endpoint: "192.168.0.2",
+					Endpoint: "endpoint-2",
 				},
 			}
-			etcdCluster.MockMembers.MembersOutput = []etcd.Member{}
+			etcdAPIMock.MembersMock.MembersOutput = []etcd.Member{}
+		})
 
+		It("adds the required TLS flags", func() {
 			etcdFlags, err := bootstrapper.GenerateEtcdFlags()
-			flags := strings.Split(etcdFlags, "\n")
 			Expect(err).To(BeNil())
+			flags := strings.Split(etcdFlags, "\n")
 			Expect(flags).To(ContainElement("ETCD_INITIAL_CLUSTER_STATE=new"))
-			Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_INITIAL_CLUSTER=%v=%v,"+
-				"test-new-cluster-instance-id-1=https://192.168.0.1:2380,"+
-				"test-new-cluster-instance-id-2=https://192.168.0.2:2380", localInstanceID, localPeerURL)))
+			Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_INITIAL_CLUSTER=%s=%s,%s=%s,%s=%s",
+				localInstanceID, localAdvertisePeerURL,
+				"test-new-cluster-instance-id-1", "https://endpoint-1:2380",
+				"test-new-cluster-instance-id-2", "https://endpoint-2:2380")))
 			Expect(flags).To(ContainElement("ETCD_NAME=" + localInstanceID))
-			Expect(flags).To(ContainElement("ETCD_INITIAL_ADVERTISE_PEER_URLS=" + localPeerURL))
-			Expect(flags).To(ContainElement("ETCD_LISTEN_PEER_URLS=" + localPeerURL))
-			Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_LISTEN_CLIENT_URLS=%v,%v", localClientURL,
-				bootstrapper.clientURL("127.0.0.1"))))
-			Expect(flags).To(ContainElement("ETCD_ADVERTISE_CLIENT_URLS=" + localClientURL))
+			Expect(flags).To(ContainElement("ETCD_INITIAL_ADVERTISE_PEER_URLS=" + localAdvertisePeerURL))
+			Expect(flags).To(ContainElement("ETCD_ADVERTISE_CLIENT_URLS=" + localAdvertiseClientURL))
+			Expect(flags).To(ContainElement("ETCD_LISTEN_PEER_URLS=" + localListenPeerURL))
+			Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_LISTEN_CLIENT_URLS=%s,%s",
+				localListenClientURL, bootstrapper.clientURL("127.0.0.1"))))
 			// TLS flags
 			Expect(flags).To(ContainElement("ETCD_CLIENT_CERT_AUTH=true"))
 			Expect(flags).To(ContainElement("ETCD_TRUSTED_CA_FILE=" + serverCA))
@@ -378,11 +411,11 @@ var _ = Describe("Bootstrap", func() {
 	})
 })
 
-// MockEtcdCluster for mocking calls to the etcd cluster package client
-type MockEtcdCluster struct {
-	MockMembers      *Members
-	MockRemoveMember *RemoveMember
-	MockAddMember    *AddMember
+// EtcdAPIMock for mocking calls to the etcd cluster package client
+type EtcdAPIMock struct {
+	MembersMock      *Members
+	RemoveMemberMock *RemoveMember
+	AddMemberMock    *AddMember
 }
 
 // Members sets the expected output for Members() on EtcdCluster
@@ -392,38 +425,45 @@ type Members struct {
 }
 
 // Members mocks the etcd cluster package client
-func (t MockEtcdCluster) Members() ([]etcd.Member, error) {
-	return t.MockMembers.MembersOutput, t.MockMembers.Err
+func (t EtcdAPIMock) Members() ([]etcd.Member, error) {
+	return t.MembersMock.MembersOutput, t.MembersMock.Err
 }
 
 // RemoveMember sets the expected input for RemoveMember() on EtcdCluster
 type RemoveMember struct {
-	ExpectedInputs []string
-	Err            error
+	Called        bool
+	ExpectedInput *string
+	Err           error
 }
 
-// RemoveMember mocks the etcd cluster package client
-func (t MockEtcdCluster) RemoveMember(peerURL string) error {
-	Expect(t.MockRemoveMember.ExpectedInputs).To(ContainElement(peerURL))
-	return t.MockRemoveMember.Err
+// RemoveMemberByName mocks the etcd cluster package client
+func (t EtcdAPIMock) RemoveMemberByName(name string) error {
+	t.RemoveMemberMock.Called = true
+	Expect(t.RemoveMemberMock.ExpectedInput).To(Not(BeNil()), "unexpected RemoveMember call with %q", name)
+	Expect(*t.RemoveMemberMock.ExpectedInput).To(Equal(name), "unexpected RemoveMember call")
+	return t.RemoveMemberMock.Err
 }
 
 // AddMember sets the expected input for AddMember() on EtcdCluster
 type AddMember struct {
-	ExpectedInput string
+	Called        bool
+	ExpectedInput *string
 	Err           error
 }
 
-// AddMember mocks the etcd cluster package client
-func (t MockEtcdCluster) AddMember(peerURL string) error {
-	Expect(peerURL).To(Equal(t.MockAddMember.ExpectedInput))
-	return t.MockAddMember.Err
+// AddMemberByPeerURL mocks the etcd cluster package client
+func (t EtcdAPIMock) AddMemberByPeerURL(peerURL string) error {
+	t.AddMemberMock.Called = true
+	Expect(t.AddMemberMock.ExpectedInput).To(Not(BeNil()), "unexpected AddMember call with %q", peerURL)
+	Expect(*t.AddMemberMock.ExpectedInput).To(Equal(peerURL), "unexpected AddMember call")
+	return t.AddMemberMock.Err
 }
 
-// CloudProvider for mocking calls to an etcd-bootstrap cloud provider
-type CloudProvider struct {
-	MockGetInstances     *GetInstances
-	MockGetLocalInstance *GetLocalInstance
+// CloudAPIMock for mocking calls to an etcd-bootstrap cloud provider
+type CloudAPIMock struct {
+	GetInstancesMock     *GetInstances
+	GetLocalInstanceMock *GetLocalInstance
+	GetLocalIPMock       *GetLocalIP
 }
 
 // GetInstances sets the expected output for GetInstances() on CloudProvider
@@ -433,8 +473,8 @@ type GetInstances struct {
 }
 
 // GetInstances mocks the etcd-bootstrap cloud provider
-func (t CloudProvider) GetInstances() ([]cloud.Instance, error) {
-	return t.MockGetInstances.GetInstancesOutput, t.MockGetInstances.Error
+func (t CloudAPIMock) GetInstances() ([]cloud.Instance, error) {
+	return t.GetInstancesMock.GetInstancesOutput, t.GetInstancesMock.Error
 }
 
 // GetLocalInstance sets the expected output for GetLocalInstance() on CloudProvider
@@ -444,6 +484,15 @@ type GetLocalInstance struct {
 }
 
 // GetLocalInstance mocks the etcd-bootstrap cloud provider
-func (t CloudProvider) GetLocalInstance() (cloud.Instance, error) {
-	return t.MockGetLocalInstance.GetLocalInstance, t.MockGetLocalInstance.Error
+func (t CloudAPIMock) GetLocalInstance() (cloud.Instance, error) {
+	return t.GetLocalInstanceMock.GetLocalInstance, t.GetLocalInstanceMock.Error
+}
+
+type GetLocalIP struct {
+	LocalIP string
+	Error   error
+}
+
+func (t CloudAPIMock) GetLocalIP() (string, error) {
+	return t.GetLocalIPMock.LocalIP, t.GetLocalIPMock.Error
 }

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -114,8 +114,8 @@ var _ = Describe("Bootstrap", func() {
 		Expect(err).To(BeNil())
 	})
 
-	It("fails when it cannot add etcd member", func() {
-		By("Returning some instances including the local instance")
+	It("fails when it cannot add the local instance as a new etcd member", func() {
+		By("The cloudAPI returns instances including the local instance")
 		cloudAPIMock.GetInstancesMock.GetInstancesOutput = []cloud.Instance{
 			{
 				Name:     localInstanceID,
@@ -127,21 +127,19 @@ var _ = Describe("Bootstrap", func() {
 			},
 		}
 
-		By("Returning an etcd member list requiring an update")
+		By("The etcd API only returns one member, missing the local instance")
 		etcdAPIMock.MembersMock.MembersOutput = []etcd.Member{
 			{
 				Name:    "test-add-instance-id-1",
-				PeerURL: "http://endopoint-1:2380",
+				PeerURL: "http://endpoint-1:2380",
 			},
 		}
 
-		By("Returning an error when attempting to list all etcd members")
+		By("Returning an error when attempting to add the local instance to the etcd API")
 		etcdAPIMock.AddMemberMock.ExpectedInput = &localAdvertisePeerURL
 		etcdAPIMock.AddMemberMock.Err = fmt.Errorf("failed to add etcd member")
 		_, err := bootstrapper.GenerateEtcdFlags()
-
-		By("Do not fail as it may be down to an etcd quorum issue")
-		Expect(err).ToNot(BeNil())
+		Expect(err).ToNot(Succeed())
 	})
 
 	Describe("new cluster", func() {

--- a/bootstrap/reconcile.go
+++ b/bootstrap/reconcile.go
@@ -6,6 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// reconcileMembers uses the etcd API to remove any non-existing members and add new ones that
+// need to join. This is used primarily to handle node replacement.
 func (b *Bootstrapper) reconcileMembers() error {
 	if err := b.removeOldEtcdMembers(); err != nil {
 		return err
@@ -13,6 +15,9 @@ func (b *Bootstrapper) reconcileMembers() error {
 	return b.addLocalInstanceToEtcd()
 }
 
+// removeOldEtcdMembers removes any etcd members that are no longer part of the instances
+// returned by the cloud API. We assume if it's not part of the cloud instances then the actual
+// node VM has been removed.
 func (b *Bootstrapper) removeOldEtcdMembers() error {
 	members, err := b.etcdAPI.Members()
 	if err != nil {
@@ -31,8 +36,10 @@ func (b *Bootstrapper) removeOldEtcdMembers() error {
 
 	for _, member := range members {
 		if !contains(instanceNames, member.Name) {
+			// The etcd member name doesn't exist in the list of cloud instances.
 			if member.Name == "" && contains(instanceURLs, member.PeerURL) {
-				// This member is still initialising, don't remove it.
+				// A special case is when member.Name == "". This means the member is still initialising, so don't remove it.
+				// Unless the peerURL doesn't exist in the instance list either, in which case this node is no longer around.
 				continue
 			}
 			log.Infof("Removing %s (%s) from etcd member list, not found in cloud provider", member.Name, member.PeerURL)
@@ -46,6 +53,11 @@ func (b *Bootstrapper) removeOldEtcdMembers() error {
 	return nil
 }
 
+// addLocalInstanceToEtcd ensures the advertise peerURL is added to the existing cluster. This is required by
+// etcd prior to a node joining a cluster, as described in https://etcd.io/docs/v3.4.0/op-guide/runtime-configuration/.
+//
+// After the peerURL is added, the member will show up with a blank name when listing members from the etcd API.
+// Once it successfully joins the name will be set.
 func (b *Bootstrapper) addLocalInstanceToEtcd() error {
 	members, err := b.etcdAPI.Members()
 	if err != nil {
@@ -63,8 +75,10 @@ func (b *Bootstrapper) addLocalInstanceToEtcd() error {
 	}
 
 	if !contains(memberNames, localInstance.Name) &&
-		// Don't re-add if the local instance's peerURL has already been added.
 		!contains(memberURLs, b.peerURL(localInstance.Endpoint)) {
+		// Don't add if the member name already exists - the local instance is already part of the cluster.
+		// Also don't re-add if the local instance's peerURL has already been added. This could happen
+		// if the node crashed or restarted before it registered.
 
 		log.Infof("Adding local instance %v to the etcd member list", localInstance)
 		localInstanceURL := b.peerURL(localInstance.Endpoint)

--- a/bootstrap/reconcile.go
+++ b/bootstrap/reconcile.go
@@ -1,0 +1,77 @@
+package bootstrap
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func (b *Bootstrapper) reconcileMembers() error {
+	if err := b.removeOldEtcdMembers(); err != nil {
+		return err
+	}
+	return b.addLocalInstanceToEtcd()
+}
+
+func (b *Bootstrapper) removeOldEtcdMembers() error {
+	members, err := b.etcdAPI.Members()
+	if err != nil {
+		return err
+	}
+	instances, err := b.cloudAPI.GetInstances()
+	if err != nil {
+		return err
+	}
+	var instanceNames []string
+	var instanceURLs []string
+	for _, instance := range instances {
+		instanceNames = append(instanceNames, instance.Name)
+		instanceURLs = append(instanceURLs, b.peerURL(instance.Endpoint))
+	}
+
+	for _, member := range members {
+		if !contains(instanceNames, member.Name) {
+			if member.Name == "" && contains(instanceURLs, member.PeerURL) {
+				// This member is still initialising, don't remove it.
+				continue
+			}
+			log.Infof("Removing %s (%s) from etcd member list, not found in cloud provider", member.Name, member.PeerURL)
+			if err := b.etcdAPI.RemoveMemberByName(member.Name); err != nil {
+				log.Warnf("Unable to remove old member. This may be due to temporary lack of quorum,"+
+					" will ignore: %v", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (b *Bootstrapper) addLocalInstanceToEtcd() error {
+	members, err := b.etcdAPI.Members()
+	if err != nil {
+		return err
+	}
+	var memberNames []string
+	var memberURLs []string
+	for _, member := range members {
+		memberNames = append(memberNames, member.Name)
+		memberURLs = append(memberURLs, member.PeerURL)
+	}
+	localInstance, err := b.cloudAPI.GetLocalInstance()
+	if err != nil {
+		return err
+	}
+
+	if !contains(memberNames, localInstance.Name) &&
+		// Don't re-add if the local instance's peerURL has already been added.
+		!contains(memberURLs, b.peerURL(localInstance.Endpoint)) {
+
+		log.Infof("Adding local instance %v to the etcd member list", localInstance)
+		localInstanceURL := b.peerURL(localInstance.Endpoint)
+		if err := b.etcdAPI.AddMemberByPeerURL(localInstanceURL); err != nil {
+			return fmt.Errorf("unexpected error when adding new member URL %s: %v", localInstanceURL, err)
+		}
+	}
+
+	return nil
+}

--- a/cloud/aws/aws.go
+++ b/cloud/aws/aws.go
@@ -54,12 +54,21 @@ func (m *AWS) GetInstances() ([]cloud.Instance, error) {
 func (m *AWS) GetLocalInstance() (cloud.Instance, error) {
 	identityDoc, err := m.getIdentityDoc()
 	if err != nil {
-		return cloud.Instance{}, nil
+		return cloud.Instance{}, err
 	}
 	return cloud.Instance{
 		Name:     identityDoc.InstanceID,
 		Endpoint: identityDoc.PrivateIP,
 	}, nil
+}
+
+// GetLocalIP returns the local instance's PrivateIP.
+func (m *AWS) GetLocalIP() (string, error) {
+	localInstance, err := m.GetLocalInstance()
+	if err != nil {
+		return "", err
+	}
+	return localInstance.Endpoint, nil
 }
 
 func (m *AWS) getIdentityDoc() (*ec2metadata.EC2InstanceIdentityDocument, error) {

--- a/cloud/aws/aws_test.go
+++ b/cloud/aws/aws_test.go
@@ -73,6 +73,10 @@ var _ = Describe("AWS Provider", func() {
 				Endpoint: localPrivateIP,
 			}))
 		})
+
+		It("returns the local IP as the local private IP", func() {
+			Expect(awsProvider.GetLocalIP()).To(Equal(localPrivateIP))
+		})
 	})
 
 	Context("AWS clients", func() {

--- a/cloud/gcp/gcp.go
+++ b/cloud/gcp/gcp.go
@@ -37,6 +37,12 @@ func (m *Members) GetLocalInstance() (cloud.Instance, error) {
 	return m.instance, nil
 }
 
+// GetLocalIP returns the same value as the GetLocalInstance() endpoint.
+func (m *Members) GetLocalIP() (string, error) {
+	localInstance, _ := m.GetLocalInstance()
+	return localInstance.Endpoint, nil
+}
+
 // NewGCP returns the Members matching the cfg.
 func NewGCP(cfg *Config) (*Members, error) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cloud/srv/srv.go
+++ b/cloud/srv/srv.go
@@ -27,7 +27,7 @@ type SRV struct {
 
 // LocalResolver finds the IP address associated with the local instance.
 type LocalResolver interface {
-	LookupLocalIP() (net.IP, error)
+	GetLocalIP() (string, error)
 }
 
 type resolver interface {
@@ -110,7 +110,7 @@ func (s *SRV) lookupInstanceAddresses(instances []cloud.Instance) (map[cloud.Ins
 }
 
 func (s *SRV) findLocalInstance() (cloud.Instance, error) {
-	localIP, err := s.localResolver.LookupLocalIP()
+	localIP, err := s.localResolver.GetLocalIP()
 	if err != nil {
 		return cloud.Instance{}, fmt.Errorf("unable to lookup local IP: %w", err)
 	}
@@ -125,7 +125,7 @@ func (s *SRV) findLocalInstance() (cloud.Instance, error) {
 
 	for instance, addrs := range instanceAddrs {
 		for _, addr := range addrs {
-			if localIP.Equal(net.ParseIP(addr)) {
+			if localIP == addr {
 				return instance, nil
 			}
 		}
@@ -143,4 +143,9 @@ func (s *SRV) GetLocalInstance() (cloud.Instance, error) {
 		s.localInstance = &instance
 	}
 	return *s.localInstance, nil
+}
+
+// GetLocalIP returns the local IP delegating to the LocalResolver.
+func (s *SRV) GetLocalIP() (string, error) {
+	return s.localResolver.GetLocalIP()
 }

--- a/cloud/srv/srv_test.go
+++ b/cloud/srv/srv_test.go
@@ -56,7 +56,7 @@ var _ = Describe("SRV Instances", func() {
 			sentHostAddrs: sentHostAddrs,
 		}
 		localResolver = &stubLocalResolver{
-			sentIP: net.ParseIP("10.10.10.2"),
+			sentIP: "10.10.10.2",
 		}
 		srv = New(domainName, service, localResolver)
 		srv.resolver = resolver
@@ -123,10 +123,10 @@ func (r *stubResolver) LookupHost(ctx context.Context, host string) (addrs []str
 }
 
 type stubLocalResolver struct {
-	sentIP  net.IP
+	sentIP  string
 	sentErr error
 }
 
-func (r *stubLocalResolver) LookupLocalIP() (net.IP, error) {
+func (r *stubLocalResolver) GetLocalIP() (string, error) {
 	return r.sentIP, r.sentErr
 }

--- a/cloud/vmware/vmware.go
+++ b/cloud/vmware/vmware.go
@@ -54,6 +54,12 @@ func (m *Members) GetLocalInstance() (cloud.Instance, error) {
 	return m.instance, nil
 }
 
+// GetLocalIP returns the same value as the GetLocalInstance() endpoint.
+func (m *Members) GetLocalIP() (string, error) {
+	localInstance, _ := m.GetLocalInstance()
+	return localInstance.Endpoint, nil
+}
+
 // NewVMware returns the Members this local instance belongs to.
 func NewVMware(cfg *Config) (*Members, error) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/gcp.go
+++ b/cmd/gcp.go
@@ -47,7 +47,7 @@ func gcp(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("Failed to create etcd cluster API: %v", err)
 	}
-	bootstrapper, err := bootstrap.New(gcpProvider, gcpProvider, etcdCluster)
+	bootstrapper, err := bootstrap.New(gcpProvider, etcdCluster)
 	if err != nil {
 		log.Fatalf("Failed to create etcd bootstrapper: %v", err)
 	}

--- a/cmd/vmware.go
+++ b/cmd/vmware.go
@@ -83,7 +83,7 @@ func vmware(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("Failed to create etcd cluster API: %v", err)
 	}
-	bootstrapper, err := bootstrap.New(vmwareProvider, vmwareProvider, etcdCluster)
+	bootstrapper, err := bootstrap.New(vmwareProvider, etcdCluster)
 	if err != nil {
 		log.Fatalf("Failed to create etcd bootstrapper: %v", err)
 	}


### PR DESCRIPTION
This is a fairly significant change as a lot of the internal
reconciliation logic of etcd-bootstrap was assuming local IP to be
equivalent to the advertise URL.

There were also some subtle edge cases that were not very obvious in the
code - I have tried to add additional comments, and improve the tests to
make these more obvious.

The most complex case is that where a peerURL has been added, but the
etcd node has not registered itself yet. We have to be careful to set
the initial cluster correctly - it should not include the to-be-added
node.