### PR TITLE
Fix TLS configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ ldflags := -X "github.com/sky-uk/etcd-bootstrap/cmd.version=$(version)" -X "gith
 
 .PHONY: all format test build setup vet lint check-format check docker release
 
-all : format check install
-check : vet lint test
+all : check install
+check : check-format vet lint test
 travis : setup check-format check build docker
 
 setup:

--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -140,7 +140,7 @@ type registrationProvider interface {
 	Update([]cloud.Instance) error
 }
 
-func createEtcdClusterAPI(instances etcd.Instances) *etcd.ClusterAPI {
+func createEtcdClusterAPI(instances etcd.CloudAPI) *etcd.ClusterAPI {
 	var etcdOpts []etcd.Option
 	if enableTLS {
 		etcdOpts = []etcd.Option{etcd.WithTLS(peerCA, peerCert, peerKey)}


### PR DESCRIPTION
We weren't setting the transport correctly.

Also significantly expand bad certificate detection, so any sort of TLS
failure will be caught by etcd bootstrap failing.

Also a small fix to the Makefile as it wasn't properly checking formatting.