### PR TITLE
Include the joining node in the initial cluster list

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -197,6 +197,9 @@ func (b *Bootstrapper) createEtcdConfigForNewCluster() (string, error) {
 // This should only be used for a node that is joining an already existing cluster. The node should
 // not be registered yet in the cluster (its name does not appear in the cluster member list). However,
 // its peerURL should have been added so the cluster will accept it when it starts up.
+//
+// The local node must also be included in the initial cluster list, which should happen if its
+// peerURL was added in the reconcile step.
 func (b *Bootstrapper) createEtcdConfigForExistingCluster() (string, error) {
 	members, err := b.etcdAPI.Members()
 	if err != nil {
@@ -204,10 +207,6 @@ func (b *Bootstrapper) createEtcdConfigForExistingCluster() (string, error) {
 	}
 	var initialClusterURLs []string
 	for _, member := range members {
-		if member.Name == "" {
-			// Don't include the joining node. Its peerURL will be set, but the name will be blank.
-			continue
-		}
 		initialClusterURLs = append(initialClusterURLs, member.PeerURL)
 	}
 	return b.createEtcdConfig(existingCluster, initialClusterURLs)

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -310,7 +310,7 @@ var _ = Describe("Bootstrap", func() {
 				},
 			}
 
-			By("Returning a list of etcd members that contains the local instance as partially initialised")
+			By("Returning a list of etcd members that contains the local instance as ready to join")
 			etcdAPIMock.MembersMock.MembersOutput = []etcd.Member{
 				{
 					// Name will be blank after adding the peerURL until the instance registers itself.
@@ -334,7 +334,8 @@ var _ = Describe("Bootstrap", func() {
 
 			flags := strings.Split(etcdFlags, "\n")
 			Expect(flags).To(ContainElement("ETCD_INITIAL_CLUSTER_STATE=existing"))
-			Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_INITIAL_CLUSTER=%s=%s,%s=%s",
+			Expect(flags).To(ContainElement(fmt.Sprintf("ETCD_INITIAL_CLUSTER=%s=%s,%s=%s,%s=%s",
+				localInstanceID, localAdvertisePeerURL,
 				"test-existing-cluster-partially-initialised-instance-id-1", "http://endpoint-1:2380",
 				"test-existing-cluster-partially-initialised-instance-id-2", "http://endpoint-2:2380")))
 			Expect(flags).To(ContainElement("ETCD_NAME=" + localInstanceID))


### PR DESCRIPTION
This is required for joining nodes - see
https://etcd.io/docs/v3.4.0/op-guide/runtime-configuration/#add-a-new-member.