### PR TITLE
Don't call DeregisterTargets if no targets need to be deregistered

### DIFF
--- a/cloud/aws/lb_target_group.go
+++ b/cloud/aws/lb_target_group.go
@@ -101,14 +101,16 @@ func (l LBTargetGroupRegistrationProvider) Update(instances []cloud.Instance) er
 		}
 	}
 
-	deregisterEtcdInstances := &elbv2.DeregisterTargetsInput{
-		TargetGroupArn: targetGroupARN,
-		Targets:        targetsToRemove,
-	}
+	if len(targetsToRemove) > 0 {
+		deregisterEtcdInstances := &elbv2.DeregisterTargetsInput{
+			TargetGroupArn: targetGroupARN,
+			Targets:        targetsToRemove,
+		}
 
-	_, err = l.elb.DeregisterTargets(deregisterEtcdInstances)
-	if err != nil {
-		return fmt.Errorf("unable to deregister etcd instances from loadbalancer target group: %v", err)
+		_, err = l.elb.DeregisterTargets(deregisterEtcdInstances)
+		if err != nil {
+			return fmt.Errorf("unable to deregister etcd instances from loadbalancer target group: %v", err)
+		}
 	}
 
 	return nil

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"errors"
+
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elbv2"
@@ -115,6 +117,9 @@ type DeregisterTargets struct {
 
 // DeregisterTargets mocks the aws elb client
 func (t AWSELBClient) DeregisterTargets(e *elbv2.DeregisterTargetsInput) (*elbv2.DeregisterTargetsOutput, error) {
+	if len(e.Targets) == 0 {
+		return nil, errors.New("ValidationError: Targets must be specified")
+	}
 	gomega.Expect(e).To(gomega.Equal(t.MockDeregisterTargets.ExpectedInput))
 	return t.MockDeregisterTargets.DeregisterTargetsOutput, t.MockDeregisterTargets.Err
 }


### PR DESCRIPTION
Calling DeregisterTargets with an empty list of Targets is rejected by the
AWS API with a ValidationError